### PR TITLE
Update .NET/Java ELN configuration

### DIFF
--- a/configs/sst_dotnet_java-dotnet.yaml
+++ b/configs/sst_dotnet_java-dotnet.yaml
@@ -1,0 +1,15 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: .NET
+  description: .NET and .NET Core SDK, tools and runtime
+  maintainer: sst_dotnet_java
+
+  arch_packages:
+    x86_64:
+    - dotnet-sdk-3.1
+    - dotnet-runtime-3.1
+    - aspnetcore-runtime-3.1
+
+  labels:
+  - eln

--- a/configs/sst_dotnet_java-java.yaml
+++ b/configs/sst_dotnet_java-java.yaml
@@ -1,0 +1,14 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: OpenJDK
+  description: OpenJDK and the Java Platform
+  maintainer: sst_dotnet_java
+
+  packages:
+  - java-1.8.0-openjdk
+  - java-11-openjdk
+  - icedtea-web
+
+  labels:
+  - eln


### PR DESCRIPTION
I don't know what I am doing. This is me asking for advice.

1. Am I supposed to modify these files that say they are generated from rhel 8 appstream? Is there some other workload file where I should be placing things we want as candidates for ELN? Should I be creating new ones?

1. OpenJDK exists in a couple of locations:

```
configs/prototype-eln-buildroot-workload.yaml          
470:        - java-11-openjdk-devel                                                                                    
471:        - java-1.8.0-openjdk-javadoc                                                                               
472:        - java-1.8.0-openjdk-javadoc-zip
                                                           
configs/rhel-8-appstream-comps-additional-devel.yaml
26:  - java-1.8.0-openjdk-devel
                                                                                                                       
configs/rhel-8-appstream-comps-java-platform.yaml                                                                      
10:  - java-1.8.0-openjdk                                                                                              
                                                                                                                       
configs-temporarily-disabled/fedora-rawhide-comps-java-development.yaml
11:  - java-1.8.0-openjdk-devel                                                                                        
50:  - java-1.8.0-openjdk-demo                                                                                         
51:  - java-1.8.0-openjdk-javadoc                  
52:  - java-1.8.0-openjdk-src                    
                                                                                                                       
configs-temporarily-disabled/fedora-rawhide-comps-javaenterprise.yaml
10:  - java-1.8.0-openjdk          
11:  - java-1.8.0-openjdk-devel        
                                                           
configs-temporarily-disabled/fedora-rawhide-comps-java.yaml 
9:  - java-1.8.0-openjdk
```

Which one should we use if we want to manipulate ELN?

3. Some of these packages don't exist yet. We expect to introduce them to Fedora as upstream releases happen. Is that okay? 

This is mostly a guess based on:

- https://fedoraproject.org/wiki/Changes/Java11
- https://devblogs.microsoft.com/dotnet/introducing-net-5/