### PR TITLE
Mark python2.7 and python3.6 as unwanted

### DIFF
--- a/configs/view-eln.yaml
+++ b/configs/view-eln.yaml
@@ -60,3 +60,11 @@ data:
   - python2-pycryptodomex
   - python3-ecdsa
   - python3-pycryptodomex
+
+  # Petr Viktorin:
+  # Python 2.7 not maintained upstream, and marked as deprecated()
+  # in Fedora.
+  - python2.7
+  # Python 3.6 is quickly becoming obsolete, and might presumably
+  # be pulled into a RHEL-like environment.
+  - python3.6


### PR DESCRIPTION
Python 2.7 not maintained upstream, and marked as `deprecated()` in Fedora.

Python 3.6 is quickly becoming obsolete, and might presumably be pulled into a RHEL-like environment.