### PR TITLE
Add sst_front_door web console workload

### DIFF
--- a/configs/sst_front_door-unwanted.yaml
+++ b/configs/sst_front_door-unwanted.yaml
@@ -1,0 +1,13 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Unwanted Packages -- sst_front_door
+  description: Packages that should not be distributed in RHEL 9
+  maintainer: sst_front_door
+  labels:
+    - cockpit
+    - web-console
+
+  unwanted_packages:
+    # only needed for integration tests (buildroot), never ship this
+    - cockpit-tests

--- a/configs/sst_front_door-web-console.yaml
+++ b/configs/sst_front_door-web-console.yaml
@@ -1,0 +1,21 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Web Console (Cockpit)
+  description: Cockpit basic packages and supported applications
+  maintainer: sst_front_door
+  labels:
+    - cockpit
+    - web-console
+
+  packages:
+    # meta-package for the basic stuff (web server, bridge, core pages)
+    - cockpit
+    # recommended packages from cockpit metapackage
+    - cockpit-packagekit
+    - cockpit-storaged
+    - cockpit-pcp
+    # web console applications developed by Front Door SST
+    - cockpit-composer
+    # in container-tools stream in RHEL 8, but not in a module in Fedora
+    - cockpit-podman


### PR DESCRIPTION
I have some things that are still unclear to me:

 * cockpit-podman is part of the "container-tools" module. Should that still live here, or are modules handled specially?

 * The "cockpit" package already has a few "Recommends", like cockpit-packagekit. We definitively want them in RHEL 9. Should they be repeated explicitly in the yaml here, or is it fine to rely on `Recommends:`?

Thanks!