### PR TITLE
Update jmc ELN configuration

### DIFF
--- a/configs/sst_dotnet_java-jmc.yaml
+++ b/configs/sst_dotnet_java-jmc.yaml
@@ -4,6 +4,9 @@ data:
   name: JMC
   description: JDK Mission Control application and libraries
   maintainer: sst_dotnet_java
+
+  modules_enable:
+  - jmc:latest
   
   packages: []
 

--- a/configs/sst_dotnet_java-jmc.yaml
+++ b/configs/sst_dotnet_java-jmc.yaml
@@ -1,0 +1,15 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: JMC
+  description: JDK Mission Control application and libraries
+  maintainer: sst_dotnet_java
+  
+  packages: []
+
+  arch_packages:
+    x86_64:
+    - jmc
+    - jmc-core
+  labels:
+  - eln


### PR DESCRIPTION
Hi, this adds JMC which is also under sst_dotnet_java. I copied from what was done in https://github.com/minimization/content-resolver-input/pull/22

JMC is delivered as a module in Fedora, does that change anything?