### PR TITLE
pytoml is deprecated and hence unwanted in ELN

### DIFF
--- a/configs/unwanted-eln-packages.yaml
+++ b/configs/unwanted-eln-packages.yaml
@@ -85,6 +85,7 @@ data:
   # deprected() Python packages:
   - python3-nose
   - python3-pytest4
+  - python3-pytoml
 
   # Radek Vykydal:
   # system-config-kickstart has been deprecated upstream, it has not


### PR DESCRIPTION
See https://fedoraproject.org/wiki/Changes/DeprecatePytoml

Sorry for the unrelated newline change, I've used the integrated GitHub editor and it just does this.