### PR TITLE
Split Front Door web console workload

### DIFF
--- a/configs/sst_front_door-composer.yaml
+++ b/configs/sst_front_door-composer.yaml
@@ -1,0 +1,11 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Composer Web Console UI
+  description: Cockpit page for composer
+  maintainer: sst_front_door
+  labels:
+    - eln
+
+  packages:
+    - cockpit-composer

--- a/configs/sst_front_door-podman.yaml
+++ b/configs/sst_front_door-podman.yaml
@@ -1,0 +1,12 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Podman Web Console UI
+  description: Cockpit page for podman administration
+  maintainer: sst_front_door
+  labels:
+    - eln
+
+  packages:
+    # in container-tools stream in RHEL 8, but not in a module in Fedora
+    - cockpit-podman

--- a/configs/sst_front_door-web-console.yaml
+++ b/configs/sst_front_door-web-console.yaml
@@ -2,7 +2,7 @@ document: feedback-pipeline-workload
 version: 1
 data:
   name: Web Console (Cockpit)
-  description: Cockpit basic packages and supported applications
+  description: Cockpit basic packages
   maintainer: sst_front_door
   labels:
     - eln
@@ -14,7 +14,3 @@ data:
     - cockpit-packagekit
     - cockpit-storaged
     - cockpit-pcp
-    # web console applications developed by Front Door SST
-    - cockpit-composer
-    # in container-tools stream in RHEL 8, but not in a module in Fedora
-    - cockpit-podman


### PR DESCRIPTION
Create separate workloads for supported applications (podman and
composer), to better see and track their dependency trees.