### PR TITLE
Add a stub workload for Ansible Automation (RHAAP)

### DIFF
--- a/configs/sst_ansible_automation_platform.yaml
+++ b/configs/sst_ansible_automation_platform.yaml
@@ -1,0 +1,14 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: sst_ansible_automation_platform 
+  description: Ansible Automation 
+  maintainer: nhorman 
+  packages:
+  - podman
+  - buildah
+  - openssh-libs 
+
+  labels:
+  - eln
+


### PR DESCRIPTION
Adding an Ansible automation workload with the packages that team knows
they currently need, which they will augment as their needs become more
well understood

Signed-off-by: Neil Horman <nhorman@redhat.com>