### PR TITLE
add sst_networking-core-network-management.yaml

### DIFF
--- a/configs/sst_networking-core-network-management.yaml
+++ b/configs/sst_networking-core-network-management.yaml
@@ -1,0 +1,52 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Core Network Management
+  description: The Core Network Management tools for the local host. This includes NetworkManager and related tools.
+  maintainer: sst_networking
+  packages:
+  - ModemManager
+  - ModemManager-debugsource
+  - ModemManager-devel
+  - ModemManager-glib
+  - ModemManager-glib-devel
+  - ModemManager-vala
+  - NetworkManager
+  - NetworkManager-adsl
+  - NetworkManager-bluetooth
+  - NetworkManager-cloud-setup
+  - NetworkManager-config-connectivity-redhat
+  - NetworkManager-config-server
+  - NetworkManager-debugsource
+  - NetworkManager-dispatcher-routing-rules
+  - NetworkManager-libnm
+  - NetworkManager-libnm-devel
+  - NetworkManager-libreswan
+  - NetworkManager-libreswan-gnome
+  - NetworkManager-ovs
+  - NetworkManager-ppp
+  - NetworkManager-team
+  - NetworkManager-tui
+  - NetworkManager-wifi
+  - NetworkManager-wwan
+  - bluez
+  - bluez-libs
+  - bluez-libs-devel
+  - dhclient
+  - dnsmasq
+  - iproute2
+  - libnma
+  - libteam
+  - mobile-broadband-provider-info
+  - network-manager-applet
+  - nm-connection-editor
+  - nmstate
+  - nmstate-plugin-ovsdb
+  - python3-libnmstate
+  - teamd
+  - usb_modeswitch
+  - usb_modeswitch-data
+  - wpa_supplicant
+
+  labels:
+  - eln


### PR DESCRIPTION
Adds NetworkManager and a wider range of packages, that are optional dependencies.