### PR TITLE
Add fabtests into appstream comps infiniband

### DIFF
--- a/configs/rhel-8-appstream-comps-infiniband.yaml
+++ b/configs/rhel-8-appstream-comps-infiniband.yaml
@@ -9,5 +9,6 @@ data:
   packages:
   - mstflint
   - qperf
+  - fabtests
 document: feedback-pipeline-workload
 version: 1


### PR DESCRIPTION
Fabtests provides a set of examples that uses libfabric. It is the
test suite for libfabric.

Signed-off-by: Honggang Li <honli@redhat.com>