### PR TITLE
sst_networking-management-desktop: Fix iproute2/iproute name

### DIFF
--- a/configs/sst_networking-management-desktop.yaml
+++ b/configs/sst_networking-management-desktop.yaml
@@ -8,7 +8,7 @@ data:
   maintainer: sst_networking
   packages:
   # Core
-  - iproute2
+  - iproute
   - dhclient
   - dnsmasq
   - NetworkManager


### PR DESCRIPTION
It's actually packaged as 'iproute'.
@cathay4t @thom311 