### PR TITLE
Add crypto policies workload

### DIFF
--- a/configs/sst_platform_security-crypto-policies.yaml
+++ b/configs/sst_platform_security-crypto-policies.yaml
@@ -1,0 +1,14 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: System-wide crypto policies
+  description: Configuration and tools providing system-wide crypto policy support
+  maintainer: sst_platform_security
+
+  packages:
+  - crypto-policies
+  - crypto-policies-scripts
+  - grubby
+
+  labels:
+  - eln


### PR DESCRIPTION
Although crypto-policies should be pulled by dependencies
this adds an explicit requirement to have them included.