### PR TITLE
Add dpdk-doc to fast packet processing.

### DIFF
--- a/configs/sst_networking-fast-packet-processing.yaml
+++ b/configs/sst_networking-fast-packet-processing.yaml
@@ -11,6 +11,7 @@ data:
   - dpdk
   - dpdk-tools
   - dpdk-devel
+  - dpdk-doc
 
   labels:
   - eln


### PR DESCRIPTION
The documentation is also required.