### PR TITLE
sst_networking-fast-packet-processing: Remove nfv-host-bin.

### DIFF
--- a/configs/sst_networking-fast-packet-processing.yaml
+++ b/configs/sst_networking-fast-packet-processing.yaml
@@ -16,7 +16,6 @@ data:
   - tuned-profiles-nfv
   - tuned-profiles-nfv-guest
   - tuned-profiles-nfv-host
-  - tuned-profiles-nfv-host-bin
   - tuned-profiles-realtime
   - tuned-profiles-cpu-partitioning
 


### PR DESCRIPTION
The tuned-profiles-nfv-host-bin performance gain over
tuned-progiles-nfv-host profile is minimal.