### PR TITLE
sst_networking-management-server: add wpa_supplicant

### DIFF
--- a/configs/sst_networking-management-server.yaml
+++ b/configs/sst_networking-management-server.yaml
@@ -26,6 +26,9 @@ data:
   # IPSec
   - NetworkManager-libreswan
 
+  # MACSec / 802.1x
+  - wpa_supplicant
+
   # ADSL
   - NetworkManager-adsl
 


### PR DESCRIPTION
It is already included in desktop workload, but as it is carrying
the names "server" and "desktop", lets make it explicit that this
package is also expected on server as well.

Noticed by Davide.

@thom311 @cathay4t 