### PR TITLE
Sst_kernel_debug adds two workloads

### DIFF
--- a/configs/sst_kernel_debug-kdump.yaml
+++ b/configs/sst_kernel_debug-kdump.yaml
@@ -1,0 +1,20 @@
+---
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Kdump support
+  description: Tools necessary to support vmcore dumping and analyzing
+  maintainer: sst_kernel_debug
+  packages:
+  - kexec-tools
+  - makedumpfile
+  - Kdump-anaconda-addon
+  - memstrack
+  - crash
+  - crash-trace-command
+  - crash-ptrace-command
+  - crash-gcore-command
+  - snappy
+  - snappy-devel
+  labels:
+  - eln

--- a/configs/sst_kernel_debug-misc.yaml
+++ b/configs/sst_kernel_debug-misc.yaml
@@ -1,0 +1,16 @@
+---
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Misc admin tools
+  description: Tools necessary to support system admin
+  maintainer: sst_kernel_debug
+  packages:
+  - dmidecode
+  - python-dmidecode
+  - lshw
+  - numactl
+  - numatop
+  - irqbalance
+  labels:
+  - eln


### PR DESCRIPTION
One workload is adding packages for vmcore dumping and analysing.
The other workload is adding packages for misc system admin tools which are maintained by kernel debug sst. 