### PR TITLE
sst_virtualization_cloud: rename Azure workload

### DIFF
--- a/configs/sst_virtualization_cloud-cloud_azure.yaml
+++ b/configs/sst_virtualization_cloud-cloud_azure.yaml
@@ -1,7 +1,7 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: RHEL on public and private clouds
+  name: RHEL on Microsoft Azure
   description: Userspace agents and tools to assist running RHEL as a guest on Microsoft Azure
   maintainer: sst_virtualization_cloud
 


### PR DESCRIPTION
Fix a copy-paste error and rename "RHEL on public and private clouds"
to "RHEL on Microsoft Azure". "RHEL on public and private clouds" name
is already used by another workload.