### PR TITLE
sst_networking: mark "jimtcl" package as unwanted

### DIFF
--- a/configs/sst_networking-management-server.yaml
+++ b/configs/sst_networking-management-server.yaml
@@ -51,5 +51,10 @@ data:
   - NetworkManager-cloud-setup
   - nmstate
 
+  unwanted_packages:
+  # On RHEL-8, jimtcl was a dependency of usb_modeswitch. Since usb_modeswitch 2.6.0, the
+  # package depends on /usr/bin/tclsh (tcl). We no longer want to maintain jimtcl for RHEL9.
+  - jimtcl
+
   labels:
   - eln


### PR DESCRIPTION
On RHEL-8, the networking SST maintains jimctl as a dependency of
usb_modeswitch (2.5.x). Since usb_modeswitch 2.6.0, it no longer
depends on jimtcl but tcl (/usr/bin/tclsh). Drop the package.