### PR TITLE
Drop netsniff-ng from networking tools

### DIFF
--- a/configs/sst_networking-tools.yaml
+++ b/configs/sst_networking-tools.yaml
@@ -18,8 +18,6 @@ data:
   - lldpad
   - lldpd
   - mtr
-  # supports kselftests
-  - netsniff-ng
   - nmap
   - nmap-ncat
   - plotnetcfg


### PR DESCRIPTION
No actual need to include it.