### PR TITLE
sst_virtualization_cloud: drop cloud-utils from packages

### DIFF
--- a/configs/sst_virtualization_cloud-cloud.yaml
+++ b/configs/sst_virtualization_cloud-cloud.yaml
@@ -7,7 +7,6 @@ data:
 
   packages:
   - cloud-init
-  - cloud-utils
   - cloud-utils-growpart
 
   labels:

--- a/configs/sst_virtualization_cloud-cloud_azure.yaml
+++ b/configs/sst_virtualization_cloud-cloud_azure.yaml
@@ -7,7 +7,6 @@ data:
 
   packages:
   - cloud-init
-  - cloud-utils
   - cloud-utils-growpart
   - WALinuxAgent
   - WALinuxAgent-udev


### PR DESCRIPTION
cloud-utils (unlike cloud-utils-growpart) is not really needed and
not currently shipped with RHEL8, drop it.