### PR TITLE
mingw packages not to be included

### DIFF
--- a/configs/mingw-pkgs-exclusion.yaml
+++ b/configs/mingw-pkgs-exclusion.yaml
@@ -1,0 +1,323 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Mingw Exclusion List
+  description: mingw packages that should not be included.
+  maintainer: sst_virtualization_spice
+  unwanted_packages:
+
+  # mingw-spice-gtk
+  - mingw32-spice-gtk3
+  - mingw64-spice-gtk3
+  - mingw32-spice-glib
+  - mingw64-spice-glib
+
+  # mingw-spice-protocol
+  - mingw32-spice-protocol
+  - mingw64-spice-protocol
+
+  # mingw-spice-vdagent
+  - mingw32-spice-vdagent
+  - mingw64-spice-vdagent
+
+  # mingw-libgovirt
+  - mingw32-libgovirt
+  - mingw64-libgovirt
+  - mingw32-libgovirt-static
+  - mingw64-libgovirt-static
+
+  # mingw-usbredir
+  - mingw32-usbredir
+  - mingw64-usbredir
+  - mingw32-usbredir-static
+  - mingw64-usbredir-static
+
+  # mingw-libcacard
+  - mingw32-libcacard
+  - mingw64-libcacard
+
+  # mingw-libusbx
+  - mingw32-libusbx
+  - mingw64-libusbx
+  - mingw32-libusbx-static
+  - mingw64-libusbx-static
+
+  # mingw-virt-viewer
+  - mingw32-virt-viewer
+  - mingw64-virt-viewer
+
+  # mingw-adwaita-icon-theme
+  - mingw32-adwaita-icon-theme
+  - mingw64-adwaita-icon-theme
+
+  # mingw-atk
+  - mingw32-atk
+  - mingw64-atk
+  - mingw32-atk-static
+  - mingw64-atk-static
+
+  # mingw-bzip2
+  - mingw32-bzip2
+  - mingw64-bzip2
+  - mingw32-bzip2-static
+  - mingw64-bzip2-static
+
+  # mingw-cairo
+  - mingw32-cairo
+  - mingw64-cairo
+  - mingw32-cairo-static
+  - mingw64-cairo-static
+
+  # mingw-celt051
+  - mingw32-celt051
+  - mingw64-celt051
+  - mingw32-celt051-static
+  - mingw64-celt051-static
+
+  # mingw-dlfcn
+  - mingw32-dlfcn
+  - mingw64-dlfcn
+  - mingw32-dlfcn-static
+  - mingw64-dlfcn-static
+
+  # mingw-expat
+  - mingw32-expat
+  - mingw64-expat
+  - mingw32-expat-static
+  - mingw64-expat-static
+
+  # mingw-fontconfig
+  - mingw32-fontconfig
+  - mingw64-fontconfig
+  - mingw32-fontconfig-static
+  - mingw64-fontconfig-static
+
+  # mingw-freetype
+  - mingw32-freetype
+  - mingw64-freetype
+  - mingw32-freetype-static
+  - mingw64-freetype-static
+
+  # mingw-gdk-pixbuf
+  - mingw32-gdk-pixbuf
+  - mingw64-gdk-pixbuf
+
+  # mingw-glib-networking
+  - mingw32-glib-networking
+  - mingw64-glib-networking
+
+  # mingw-gmp
+  - mingw32-gmp
+  - mingw64-gmp
+
+  # mingw-gnutls
+  - mingw32-gnutls
+  - mingw64-gnutls
+
+  # mingw-gsm
+  - mingw32-gsm
+  - mingw64-gsm
+  - mingw32-gsm-tools
+  - mingw64-gsm-tools
+
+  # mingw-gstreamer1
+  - mingw64-gstreamer1
+  - mingw32-gstreamer1
+
+  # mingw-gstreamer1-plugins-bad-free
+  - mingw32-gstreamer1-plugins-bad-free
+  - mingw64-gstreamer1-plugins-bad-free
+
+  # mingw-gstreamer1-plugins-base
+  - mingw32-gstreamer1-plugins-base
+  - mingw64-gstreamer1-plugins-base
+
+  # mingw-gstreamer1-plugins-good
+  - mingw32-gstreamer1-plugins-good
+  - mingw64-gstreamer1-plugins-good
+
+  # mingw-gtk3
+  - mingw32-gtk3
+  - mingw64-gtk3
+  - mingw32-gtk-update-icon-cache
+  - mingw64-gtk-update-icon-cache
+
+  # mingw-gtk-vnc
+  - mingw32-gtk-vnc2
+  - mingw64-gtk-vnc2
+  - mingw32-gvnc
+  - mingw64-gvnc
+  - mingw32-gvnc-tools
+  - mingw64-gvnc-tools
+
+  # mingw-harfbuzz
+  - mingw32-harfbuzz
+  - mingw64-harfbuzz
+  - mingw32-harfbuzz-static
+  - mingw64-harfbuzz-static
+
+  # mingw-icu
+  - mingw32-icu
+  - mingw64-icu
+
+  # mingw-ilmbase
+  - mingw32-ilmbase
+  - mingw64-ilmbase
+  - mingw32-ilmbase-static
+  - mingw64-ilmbase-static
+
+  # mingw-jasper
+  - mingw32-jasper
+  - mingw64-jasper
+  - mingw32-jasper-static
+  - mingw64-jasper-static
+
+  # mingw-libepoxy
+  - mingw32-libepoxy
+  - mingw64-libepoxy
+
+  # mingw-libgcrypt
+  - mingw32-libgcrypt
+  - mingw64-libgcrypt
+  - mingw32-libgcrypt-static
+  - mingw64-libgcrypt-static
+
+  # mingw-libgpg-error
+  - mingw32-libgpg-error
+  - mingw64-libgpg-error
+  - mingw32-libgpg-error-static
+  - mingw64-libgpg-error-static
+
+  # mingw-libjpeg-turbo
+  - mingw32-libjpeg-turbo
+  - mingw64-libjpeg-turbo
+  - mingw32-libjpeg-turbo-static
+  - mingw64-libjpeg-turbo-static
+
+  # mingw-libogg
+  - mingw32-libogg
+  - mingw64-libogg
+
+  # mingw-libpng
+  - mingw64-libpng
+  - mingw32-libpng
+  - mingw32-libpng-static
+  - mingw64-libpng-static
+
+  # mingw-libsoup
+  - mingw32-libsoup
+  - mingw64-libsoup
+
+  # mingw-libtasn1
+  - mingw32-libtasn1
+  - mingw64-libtasn1
+
+  # mingw-libtheora
+  - mingw32-libtheora
+  - mingw64-libtheora
+  - mingw32-theora-tools
+  - mingw64-theora-tools
+
+  # mingw-libtiff
+  - mingw32-libtiff
+  - mingw64-libtiff
+  - mingw32-libtiff-static
+  - mingw64-libtiff-static
+
+  # mingw-libvorbis
+  - mingw32-libvorbis
+  - mingw64-libvorbis
+
+  # mingw-libxml2
+  - mingw32-libxml2
+  - mingw64-libxml2
+  - mingw32-libxml2-static
+  - mingw64-libxml2-static
+
+  # mingw-nettle
+  - mingw32-nettle
+  - mingw64-nettle
+
+  # mingw-nspr
+  - mingw32-nspr
+  - mingw64-nspr
+  - mingw32-nspr-static
+  - mingw64-nspr-static
+
+  # mingw-nss
+  - mingw32-nss
+  - mingw64-nss
+
+  # mingw-OpenEXR
+  - mingw32-OpenEXR
+  - mingw64-OpenEXR
+  - mingw32-OpenEXR-static
+  - mingw64-OpenEXR-static
+  - mingw32-OpenEXR-tools
+  - mingw64-OpenEXR-tools
+
+  # mingw-openssl
+  - mingw32-openssl
+  - mingw64-openssl
+  - mingw32-openssl-static
+  - mingw64-openssl-static
+
+  # mingw-opus
+  - mingw32-opus
+  - mingw64-opus
+
+  # mingw-orc
+  - mingw32-orc
+  - mingw64-orc
+  - mingw32-orc-compiler
+  - mingw64-orc-compiler
+
+  # mingw-p11-kit
+  - mingw32-p11-kit
+  - mingw64-p11-kit
+
+  # mingw-pango
+  - mingw32-pango
+  - mingw64-pango
+  - mingw32-pango-static
+  - mingw64-pango-static
+
+  # mingw-pdcurses
+  - mingw32-pdcurses
+  - mingw64-pdcurses
+
+  # mingw-readline
+  - mingw32-readline
+  - mingw64-readline
+  - mingw32-readline-static
+  - mingw64-readline-static
+
+  # mingw-rest
+  - mingw32-rest
+  - mingw64-rest
+  - mingw32-rest-static
+  - mingw64-rest-static
+
+  # mingw-speex
+  - mingw32-speex
+  - mingw64-speex
+  - mingw32-speex-tools
+  - mingw64-speex-tools
+
+  # mingw-sqlite
+  - mingw32-sqlite
+  - mingw64-sqlite
+  - mingw32-sqlite-static
+  - mingw64-sqlite-static
+
+  # mingw-w64-tools
+  - mingw-w64-tools
+
+  # mingw-wavpack
+  - mingw32-wavpack
+  - mingw64-wavpack
+  - mingw32-wavpack-tools
+  - mingw64-wavpack-tools
+
+  labels:
+  - eln


### PR DESCRIPTION
I used a script similar to the one below to gather RPMs
given a list of packages ($PKGS)

for pkg in $PKGS; do
  b=$(koji latest-build --quiet f33 $pkg | cut -d" " -f1) # build
  v=$(echo $b | sed "s/$pkg-\(.*\).fc3./\1/") # version
  rpms=$(koji buildinfo $b | grep '^.mnt.koji' | grep -v debug |
         grep -v src.rpm | grep -E 'x86_64|noarch' |
         cut -f1)
  echo "  # $pkg"
  for rpm in $rpms; do
      n=$(echo $rpm | sed "s/-$v.*rpm//" |
          sed 's,^.mnt.koji.*fc3..[^/]*/,,')
      echo "  - $n"
  done
done