### PR TITLE
TPM packages fixup

### DIFF
--- a/configs/sst_kernel_rats-tpm-exclusion.yaml
+++ b/configs/sst_kernel_rats-tpm-exclusion.yaml
@@ -7,8 +7,6 @@ data:
 
   unwanted_packages:
   - tpm-quote-tools
-  - tpm2-abrmd
-  - tpm2-abrmd-selinux
 
   labels:
   - eln

--- a/configs/sst_kernel_rats-tpm.yaml
+++ b/configs/sst_kernel_rats-tpm.yaml
@@ -11,6 +11,9 @@ data:
   - tss2
   - tpm2-tss
   - tpm2-tools
+  # needed for gating tests
+  - tpm2-abrmd
+  - tpm2-abrmd-selinux
 
   labels:
   - eln


### PR DESCRIPTION
tpm2-abrmd and tpm2-abrmd-selinux are still needed for gating tests.

Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>