### PR TITLE
Add Platform Tools workloads for: glibc, tzdata, libffi, ltrace, make, bison, byacc, flex, and C/C++ runtime/dev.

### DIFF
--- a/configs/sst_platform_tools-c++-development-full.yaml
+++ b/configs/sst_platform_tools-c++-development-full.yaml
@@ -1,17 +1,21 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: C Development Environment
-  description: A C development environment.
+  name: C++ Development Environment
+  description: A C++ development environment.
   maintainer: sst_platform_tools
 
   packages:
   # The minimum development environment is this:
   - gcc
+  - gcc-c++
   - binutils
   - glibc
   - glibc-common
   - glibc-devel
+  - libstdc++
+  - libstdc++-devel
+  - libgcc
   # Noarch header packages.
   - glibc-headers-s390
   - glibc-headers-x86_64
@@ -19,6 +23,7 @@ data:
   - glibc-utils
   - glibc-static
   - glibc-nss-devel
+  - libstdc++-static
   # Support all locales.
   - glibc-all-langpacks
 

--- a/configs/sst_platform_tools-c++-development.yaml
+++ b/configs/sst_platform_tools-c++-development.yaml
@@ -1,20 +1,24 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: C Development Environment
-  description: A minimal C development environment.
+  name: C++ Development Environment
+  description: A minimal C++ development environment.
   maintainer: sst_platform_tools
 
   packages:
   # The minimum development environment is this:
   - gcc
+  - gcc-c++
   - binutils
   - glibc
   - glibc-common
   - glibc-devel
+  - libstdc++
+  - libstdc++-devel
+  - libgcc
   # Noarch header packages.
-  - glibc-headers-x86
   - glibc-headers-s390
+  - glibc-headers-x86_64
   # We support only the C/POSIX/C.UTF-8 locales.
   - glibc-minimal-langpack
 

--- a/configs/sst_platform_tools-c++-runtime.yaml
+++ b/configs/sst_platform_tools-c++-runtime.yaml
@@ -1,14 +1,16 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: C Runtime
-  description: A minimal C runtime.
+  name: C++ Runtime
+  description: A minimal C++ runtime.
   maintainer: sst_platform_tools
 
   packages:
   # Need the C runtime implementation.
   - glibc
   - glibc-common
+  # Need the C++ standard library implementation.
+  - libstdc++
   # Need compiler helper routines and unwinder.
   - libgcc
   # Support C/POSIX/C.UTF-8 locales.

--- a/configs/sst_platform_tools-c-development-full.yaml
+++ b/configs/sst_platform_tools-c-development-full.yaml
@@ -1,0 +1,25 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: C Runtime
+  description: C development environment.
+  maintainer: sst_platform_tools
+
+  packages:
+  # The minimum development environment is this:
+  - gcc
+  - binutils
+  - glibc
+  - glibc-common
+  - glibc-devel
+  - glibc-headers-s390
+  - glibc-headers-x86_64
+  # Full development includes additional packages:
+  - glibc-utils
+  - glibc-static
+  - glibc-nss-devel
+  # Support all locales.
+  - glibc-all-lancpacks
+
+  labels:
+  - eln

--- a/configs/sst_platform_tools-c-development.yaml
+++ b/configs/sst_platform_tools-c-development.yaml
@@ -1,0 +1,21 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: C Runtime
+  description: The minimum required C development environment.
+  maintainer: sst_platform_tools
+
+  packages:
+  # The minimum development environment is this:
+  - gcc
+  - binutils
+  - glibc
+  - glibc-common
+  - glibc-devel
+  - glibc-headers-s390
+  - glibc-headers-x86_64
+  # We support only the C/POSIX/C.UTF-8 locales.
+  - glibc-minimal-langpack
+
+  labels:
+  - eln

--- a/configs/sst_platform_tools-c-runtime.yaml
+++ b/configs/sst_platform_tools-c-runtime.yaml
@@ -1,0 +1,14 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: C Runtime
+  description: The minimum required C runtime.
+  maintainer: sst_platform_tools
+
+  packages:
+  - glibc
+  - glibc-common
+  - glibc-minimal-langpack
+
+  labels:
+  - eln

--- a/configs/sst_platform_tools-libffi.yaml
+++ b/configs/sst_platform_tools-libffi.yaml
@@ -1,0 +1,13 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: libffi
+  description: A portable foreign function interface library.
+  maintainer: sst_platform_tools
+
+  packages:
+  - libffi
+  - libffi-devel
+
+  labels:
+  - eln

--- a/configs/sst_platform_tools-ltrace.yaml
+++ b/configs/sst_platform_tools-ltrace.yaml
@@ -1,0 +1,12 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: ltrace
+  description: Developer tooling to track runtime library calls.
+  maintainer: sst_platform_tools
+
+  packages:
+  - ltrace
+
+  labels:
+  - eln

--- a/configs/sst_platform_tools-make.yaml
+++ b/configs/sst_platform_tools-make.yaml
@@ -1,0 +1,13 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: GNU Make
+  description: Application build tooling.
+  maintainer: sst_platform_tools
+
+  packages:
+  - make
+  - make-devel
+
+  labels:
+  - eln

--- a/configs/sst_platform_tools-parsegen.yaml
+++ b/configs/sst_platform_tools-parsegen.yaml
@@ -1,0 +1,18 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: bison/byacc/flex
+  description: Parser and scanner generators (bison, byacc, flex).
+  maintainer: sst_platform_tools
+
+  packages:
+  - bison
+  - bison-devel
+  - bison-runtime
+  - byacc
+  - flex
+  - flex-devel
+  - flex-doc
+
+  labels:
+  - eln

--- a/configs/sst_platform_tools-tzdata.yaml
+++ b/configs/sst_platform_tools-tzdata.yaml
@@ -1,0 +1,13 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: tzdata
+  description: The latest time zone database as released by IANA.
+  maintainer: sst_platform_tools
+
+  packages:
+  - tzdata
+  - tzdata-java
+
+  labels:
+  - eln

--- a/configs/sst_platform_tools-unwanted.yaml
+++ b/configs/sst_platform_tools-unwanted.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Platform Tools Unwanted Packages
   description: Packages that Platform Tool maintains in RHEL 8 but won't in RHEL 9
-  maintainer: Dodji Seketeli, Nick Clifton
+  maintainer: sst_platform_tools
   labels:
   - eln
 
@@ -25,3 +25,10 @@ data:
   - nasm-rdoff
   - yasm
   - yasm-devel
+  # The X11 build may require mcpp. We should try hard to remove this
+  # dependency because if we can then we can remove mcpp entirely
+  # because nothing else should use it.
+  - mcpp
+  - mcpp-doc
+  - libmcpp
+  - libmcpp-devel


### PR DESCRIPTION
The following commits contribute coverage from Platform Tools for: glibc, tzdata, libffi, ltrace, make, bison, byacc, flex.

I have additionally provided workloads to cover minimum C and C++ runtime environments, minimum C and C++ development environments, and a slightly more than minimum C and C++ development environment (includes static linking support). The development environments are very minimal and cover only the required compiler, assembler, linker, headers, objects etc. that would be required to compile, assemble, and link a C or C++ dynamic or statically linked binary or library.

In addition I have, at the request of Jeff Law, added mcpp to our unwanted_packages list and cleaned up the ownership of that list to reflect ownership by sst_platform_tools.