### PR TITLE
Mark pam_radius and freeradius-client as unwanted

### DIFF
--- a/configs/sst_identity_management-unwanted.yaml
+++ b/configs/sst_identity_management-unwanted.yaml
@@ -24,6 +24,8 @@ data:
   - python-requests-kerberos
   - mod_nss
   - mod_revocator
+  - pam_radius
+  - freeradius-client
 
   # Not supported in RHEL (https://bugzilla.redhat.com/show_bug.cgi?id=910464)
   - samba-dc


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

I maintain `freeradius` (the server package) and co-maintain `pam_radius` in EPEL and Fedora. We're keeping FreeRADIUS Server, but have no intention of pulling in `pam_radius` or `freeradius-client`. These currently aren't required by any packages in the content set, so I'm not sure if it is necessary to open a PR removing them.