### PR TITLE
networking tools: mark bridge-utils as unwanted

### DIFF
--- a/configs/sst_networking-tools.yaml
+++ b/configs/sst_networking-tools.yaml
@@ -28,5 +28,8 @@ data:
   - wireshark
   - wireshark-cli
 
+  unwanted_packages:
+  - bridge-utils
+
   labels:
   - eln


### PR DESCRIPTION
iproute should be used instead.