### PR TITLE
firewall: add unwanted ebtables-legacy

### DIFF
--- a/configs/sst_networking-firewall-unwanted.yaml
+++ b/configs/sst_networking-firewall-unwanted.yaml
@@ -11,3 +11,4 @@ data:
   unwanted_packages:
   - iptstate
   - bridge-utils
+  - ebtables-legacy


### PR DESCRIPTION
Force other workloads to use "ebtables" so when we fix the alternatives
we get the correct ebtables-nft variant.