### PR TITLE
Create sst_arch_hw-bluefield.yaml

### DIFF
--- a/sst_arch_hw-bluefield.yaml
+++ b/sst_arch_hw-bluefield.yaml
@@ -1,0 +1,16 @@
+Document: bluefield-smartnic-workload
+version: 1
+data
+name:Bluefileld                   
+  description: Packages required for Mellanox Bluefield SmartNIC
+  maintainer: sst_arch_hwl          
+  packages: []
+========================
+  labels:     
+  - eln        
+
+  arch_packages:                   
+    aach64:                    
+    - mlxbf-bootcl
+    - bfscripts
+   -  RSHIM


### PR DESCRIPTION
Packages required to support Mellanox Bluefield SmartNIC