### PR TITLE
Delete ibus-sayura from sst_i18n-input-methods.yaml

### DIFF
--- a/configs/sst_i18n-input-methods.yaml
+++ b/configs/sst_i18n-input-methods.yaml
@@ -17,7 +17,6 @@ data:
   - ibus-libpinyin
   - ibus-libzhuyin
   - ibus-m17n
-  - ibus-sayura
   - ibus-table-chinese-array
   - ibus-table-chinese-cangjie
   - ibus-table-chinese-cantonese


### PR DESCRIPTION
ibus-m17n will be used instead of ibus-sayura since RHEL9.

Signed-off-by: Takao Fujiwara <tfujiwar@redhat.com>