### PR TITLE
Make changes to the kdump workload

### DIFF
--- a/configs/sst_kernel_debug-kdump.yaml
+++ b/configs/sst_kernel_debug-kdump.yaml
@@ -7,14 +7,12 @@ data:
   maintainer: sst_kernel_debug
   packages:
   - kexec-tools
-  - makedumpfile
-  - Kdump-anaconda-addon
+  - kdump-anaconda-addon
   - memstrack
   - crash
   - crash-trace-command
-  - crash-ptrace-command
   - crash-gcore-command
+  - crash-ptdump-command
   - snappy
-  - snappy-devel
   labels:
   - eln


### PR DESCRIPTION
Remove
 - makedumpfile because it is included in kexec-tools package;
 - snappy-devel because it is part of snappy, not a package;
 - crash-ptrace-command because it is actually crash-trace-command.
Add
 - crash-ptdump-command