### PR TITLE
gcc-toolset: Add gcc-libraries to package_placeholders.

### DIFF
--- a/configs/sst_platform_tools-compat.yaml
+++ b/configs/sst_platform_tools-compat.yaml
@@ -1,0 +1,15 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Toolchain compatibility packages
+  description: >
+    Collection of packages providing compatibility packages related to
+    the GNU Toolchain.
+  maintainer: sst_platform_tools
+
+  packages:
+  # RHEL 8 bumped SONAME of libgfortran.so.  Support RHEL 7 apps.
+  - compat-libgfortran-48
+
+  labels:
+  - eln

--- a/configs/sst_platform_tools-gcc-toolset.yaml
+++ b/configs/sst_platform_tools-gcc-toolset.yaml
@@ -35,23 +35,24 @@ data:
   - chrpath
 
   package_placeholders:
-    gcc-libraries: This package might be needed to support applications built with the GCC Toolset.
-    requires:
-    - binutils
-    - glibc-devel
-    - libgcc
-    - libgomp
-    buildrequires:
-    - gcc
-    - gcc-c++
-    - gcc-gfortran
-    - binutils
-    - glibc-devel
-    - libgcc
-    - libgomp
-    - gmp-devel
-    - mpfr-devel
-    - libmpc-devel
+    gcc-libraries:
+      description: This package might be needed to support applications built with the GCC Toolset.
+      requires:
+      - binutils
+      - glibc-devel
+      - libgcc
+      - libgomp
+      buildrequires:
+      - gcc
+      - gcc-c++
+      - gcc-gfortran
+      - binutils
+      - glibc-devel
+      - libgcc
+      - libgomp
+      - gmp-devel
+      - mpfr-devel
+      - libmpc-devel
 
   labels:
   - eln

--- a/configs/sst_platform_tools-gcc-toolset.yaml
+++ b/configs/sst_platform_tools-gcc-toolset.yaml
@@ -34,5 +34,24 @@ data:
   - dwz
   - chrpath
 
+  package_placeholders:
+    gcc-libraries: This package might be needed to support applications built with the GCC Toolset.
+    requires:
+    - binutils
+    - glibc-devel
+    - libgcc
+    - libgomp
+    buildrequires:
+    - gcc
+    - gcc-c++
+    - gcc-gfortran
+    - binutils
+    - glibc-devel
+    - libgcc
+    - libgomp
+    - gmp-devel
+    - mpfr-devel
+    - libmpc-devel
+
   labels:
   - eln


### PR DESCRIPTION
We might need gcc-libraries to support applications built with the GCC Toolset, if a new toolset requires libraries not present in the system gcc.