### PR TITLE
kernel_rats-perf.yaml: Update for packages not in fedora

### DIFF
--- a/configs/sst_kernel_rats-perf.yaml
+++ b/configs/sst_kernel_rats-perf.yaml
@@ -1,13 +1,65 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-    name: realtime perf
-    description: Packages for testing realtime performance
-    maintainer: sst_kernel_rats
-    packages:
-      - realtime-tests
-      - rteval
-      - rteval-loads
-      - stress-ng
-    labels:
-      - eln
+  name: realtime perf
+  description: Packages for testing realtime performance
+  maintainer: sst_kernel_rats
+  packages:
+    - stress-ng
+  labels:
+    - eln
+
+  package_placeholders:
+    rt-tests:
+      description: This package is not in Fedora (yet), but we want it here.
+      requires:
+        - bash
+        - bc
+      buildrequires:
+        - gcc
+        - make
+        - numactl-devel
+        - python3-devel
+    rteval:
+      description: This package is not in Fedora (yet), but we want it here.
+      requires:
+        - platform-python
+        - python3schedutils
+        - python3-ethtool
+        - python3-lxml
+        - python3-dmidecode
+        - rteval-loads
+        - rteval-common
+        - systat
+        - xz
+        - bzip2
+        - kernelheaders
+        - sos
+        - tar
+        - numactl
+        - gcc
+        - flex
+        - bison
+        - bc
+        - make
+        - openssl
+        - openssl-devel
+      buildrequires:
+        - python3-devel
+      rteval-loads:
+        description: This package is not in Fedora (yet), but we want it here.
+        requires:
+          - gcc
+          - binutils
+          - make
+          - kernel-headers
+        buildrequires:
+          - gcc
+          - glibc-devel
+          - kernel-headers
+          - keyutils-libs-devel
+          - libaio-devel
+          - libattr-devel
+          - libcap-devel
+          - lksctp-tools-devel
+          - zlib-devel


### PR DESCRIPTION
- Change to rt-tests, since renaming doesn't occur at this stage.
- put packages not in Fedora in a package_placeholders: section
- update yaml spacing

Signed-off-by: John Kacur <jkacur@redhat.com>