### PR TITLE
sst_networking-tools: drop socat

### DIFF
--- a/configs/sst_networking-tools.yaml
+++ b/configs/sst_networking-tools.yaml
@@ -22,7 +22,6 @@ data:
   - nmap-ncat
   - plotnetcfg
   - python3-scapy
-  - socat
   - tcpdump
   - traceroute
   - wireshark


### PR DESCRIPTION
It is a better fit for EPEL or so.