### PR TITLE
Remove rubypick

### DIFF
--- a/configs/sst_cs_apps-unwanted-ruby.yaml
+++ b/configs/sst_cs_apps-unwanted-ruby.yaml
@@ -10,6 +10,7 @@ data:
   - rubygem-bundler-doc
   - rubygem-rspec-its
   - rubygem-rspec-its-doc
+  - rubypick
 
   labels:
   - eln


### PR DESCRIPTION
rubypick is not needed if Ruby is configured properly:

https://src.fedoraproject.org/rpms/ruby/blob/master/f/ruby.spec#_71