### PR TITLE
Make sure java-latest-openjdk does not end up in RHEL 9.

### DIFF
--- a/configs/sst_dotnet_java-unwanted.yaml
+++ b/configs/sst_dotnet_java-unwanted.yaml
@@ -10,3 +10,5 @@ data:
   unwanted_packages:
   # No Eclipse planned for RHEL 9, so seems little point in maintaining ecj, plus current deps don't need it
   - ecj
+  # RHEL should only get explicitly versioned JDKs (e.g. java-17-openjdk), not the rolling java-latest-openjdk
+  - java-latest-openjdk


### PR DESCRIPTION
java-latest-openjdk is a rolling package of the latest version of OpenJDK, which we want to make sure is explicitly excluded from RHEL.
java-17-openjdk will eventually provide the next long term support release for RHEL.