### PR TITLE
Add placeholder for java-17-openjdk

### DIFF
--- a/configs/sst_dotnet_java-java.yaml
+++ b/configs/sst_dotnet_java-java.yaml
@@ -12,3 +12,47 @@ data:
 
   labels:
   - eln
+
+  package_placeholders:
+    java-17-openjdk:
+      description: Future long-term supported release of OpenJDK
+      requires:
+        - fontconfig
+        - xorg-x11-fonts-Type1
+        - ca-certificates
+        - javapackages-filesystem
+        - tzdata-java
+        - copy-jdk-configs
+        - cups-libs
+      buildrequires:
+        - autoconf
+        - automake
+        - alsa-lib-devel
+        - binutils
+        - cups-devel
+        - desktop-file-utils
+        - elfutils-devel
+        - fontconfig-devel
+        - giflib-devel
+        - gcc-c++
+        - gdb
+        - lcms2-devel
+        - libpng-devel
+        - libjpeg-devel
+        - libX11-devel
+        - libXi-devel
+        - libXinerama-devel
+        - libXrandr-devel
+        - libXt-devel
+        - libXtst-devel
+        - libxslt
+        - nss-devel
+        - pkgconfig
+        - xorg-x11-proto-devel
+        - zip
+        - javapackages-filesystem
+        - java-latest-openjdk-devel
+        - libffi-devel
+        - tzdata-java
+        - gcc
+        - systemtap-sdt-devel


### PR DESCRIPTION
Added the future long-term support release of OpenJDK, java-17-openjdk. The dependencies are based on the current java-latest-openjdk in Fedora. java-17-openjdk will initially need java-latest-openjdk to bootstrap, but once built, it can depend on itself.