### PR TITLE
Fast content set updates

### DIFF
--- a/configs/sst_filesystems-userspace-unwanted.yaml
+++ b/configs/sst_filesystems-userspace-unwanted.yaml
@@ -5,9 +5,6 @@ data:
   description: Unwanted Filesystem Packages
   maintainer: sst_filesystems
 
-  unwanted_packages:
-    - system-storage-manager
-
   unwanted_arch_packages:
     aarch64:
       - gfs2-utils

--- a/configs/sst_filesystems-userspace.yaml
+++ b/configs/sst_filesystems-userspace.yaml
@@ -6,9 +6,36 @@ data:
   maintainer: sst_filesystems
 
   packages:
+    - autofs
     - blktrace
+    - cachefilesd
+    - cifs-utils
+    - cifs-utils-devel
     - e2fsprogs
     - fio
+    - fuse
+    - fuse-common
+    - fuse-devel
+    - fuse-libs
+    - fuse3
+    - fuse3-devel
+    - fuse3-libs
+    - keyutils
+    - keyutils-libs
+    - keyutils-libs-devel
+    - libnfsidmap
+    - libnfsidmap-devel
+    - libtirpc
+    - libtirpc-devel
+    - nfs-utils
+    - nfs-utils-coreos
+    - nfs4-acl-tools
+    - pam_cifscreds
+    - rpcbind
+    - rpcgen
+    - rpcsvc-proto
+    - rpcsvc-proto-devel
+    - system-storage-manager
     - xfsdump
     - xfsprogs
 

--- a/configs/sst_platform_storage-packages.yaml
+++ b/configs/sst_platform_storage-packages.yaml
@@ -112,8 +112,9 @@ data:
     - python3-blivet
     - python3-blockdev
     - python3-libstoragemgmt
+    - python3-pywbem
     - sg3_utils
-    - udisks
+    - udisks2
     - udisks2-iscsi
     - udisks2-lsm
     - udisks2-lvm2


### PR DESCRIPTION
After cross-checking a few more things, these updates were made.

Filesystems:
  - Added numerous packages that were overlooked.  
  - Moved system-storage-manager back to the 'claimed' status.

Platform Storage:
  - Fixed a typo in 'udisks', as it should be 'udisks2'.
  - Added a dependent package that was not previously listed.