### PR TITLE
2 more changes for the sst_kernel_rats team

### DIFF
--- a/configs/sst_kernel_rats-perf.yaml
+++ b/configs/sst_kernel_rats-perf.yaml
@@ -46,20 +46,20 @@ data:
         - openssl-devel
       buildrequires:
         - python3-devel
-      rteval-loads:
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - gcc
-          - binutils
-          - make
-          - kernel-headers
-        buildrequires:
-          - gcc
-          - glibc-devel
-          - kernel-headers
-          - keyutils-libs-devel
-          - libaio-devel
-          - libattr-devel
-          - libcap-devel
-          - lksctp-tools-devel
-          - zlib-devel
+    rteval-loads:
+      description: This package is not in Fedora (yet), but we want it here.
+      requires:
+        - gcc
+        - binutils
+        - make
+        - kernel-headers
+      buildrequires:
+        - gcc
+        - glibc-devel
+        - kernel-headers
+        - keyutils-libs-devel
+        - libaio-devel
+        - libattr-devel
+        - libcap-devel
+        - lksctp-tools-devel
+        - zlib-devel

--- a/configs/sst_kernel_rats-setup.yaml
+++ b/configs/sst_kernel_rats-setup.yaml
@@ -1,10 +1,26 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-    name: realtime setup
-    description: Package that creates realtime group and limits
-    maintainer: sst_kernel_rats
-    packages:
-        - realtime-setup
-    labels:
-        - eln
+  name: rt-setup
+  description: Package that creates realtime group and limits
+  maintainer: sst_kernel_rats
+  packages:
+    - rt-setup
+  labels:
+    - eln
+
+  package-placeholders:
+    rt-setup:
+      description: This package is not in Fedora (yet), but we want it here.
+      requires:
+        - pam
+        - groupadd
+        - kexec-tools
+        - tuna
+        - tuned
+        - tuned-profiles-realtime
+        - systemd
+      buildrequires:
+        - gcc
+        - systemd
+        - annobin


### PR DESCRIPTION
rteval-loads was not showing up, I believe because the indentation in the yaml file was not consistent, so this fixes it.
rt-setup was not showing up, because it is not in fedora, and lacked a package-placeholders section, this fixes that.