### PR TITLE
Add .NET 6.0

### DIFF
--- a/configs/sst_dotnet_java-dotnet.yaml
+++ b/configs/sst_dotnet_java-dotnet.yaml
@@ -5,13 +5,16 @@ data:
   description: .NET and .NET Core SDK, tools and runtime
   maintainer: sst_dotnet_java
   
-  packages: []
+  packages:
+  - dotnet-sdk-3.1
+  - dotnet-runtime-3.1
+  - aspnetcore-runtime-3.1
 
-  arch_packages:
-    x86_64:
-    - dotnet-sdk-3.1
-    - dotnet-runtime-3.1
-    - aspnetcore-runtime-3.1
+  package_placeholders:
+    dotnet-sdk-6.0:
+      description: .NET 6.0 doesn't exist, yet, but it's being planned for release in Nov 2021.
+      requires: []        # same dependencies as dotnet-sdk-3.1
+      buildrequires: []   # same dependencies as dotnet-sdk-3.1
 
   labels:
   - eln


### PR DESCRIPTION
Upstream expects to release this around Nov 2021. It will be an LTS release. It's probably a good idea to add it to ELN for now.