### PR TITLE
sst_kernel_rats-kernel-rt: Update for packages not in fedora

### DIFF
--- a/configs/sst_kernel_rats-kernel-rt-base.yaml
+++ b/configs/sst_kernel_rats-kernel-rt-base.yaml
@@ -5,15 +5,231 @@ data:
     description: Base set of kernel-rt packages and tools to ship
     maintainer: sst_kernel_rats
     packages:
-        - kernel-rt-core
-        - kernel-rt-modules
-        - kernel-rt-modules-extra
-        - kernel-rt-kvm
         - tuned-profiles-realtime
-        - tuned-profiles-nfv
         - tuned-profiles-nfv
         - tuned-profiles-nfv-guest
         - tuned-profiles-nfv-host
         - tuned-profiles-nfv-host-bin
     labels:
         - eln
+
+    package_placeholders:
+      kernel-rt:
+        description: This package is not in Fedora (yet), but we want it here.
+        requires:
+          - bash
+          - systemd-udev
+          - coreutils
+          - dracut
+          - linux-firmware
+          - systemd
+        buildrequires:
+          - kmod
+          - patch
+          - bash
+          - coreutils
+          - tar
+          - git
+          - which
+          - bzip2
+          - xz
+          - findutils
+          - gzip
+          - m4
+          - perl-interpreter
+          - perl-Carp
+          - perl-devel
+          - perl-generators
+          - make
+          - diffutils
+          - gawk
+          - gcc
+          - binutils
+          - redhat-rpm-config
+          - hmaccalc
+          - python3-devel
+          - net-tools
+          - hostname
+          - bc
+          - bison
+          - flex
+          - elfutils-devel
+          - dwarves
+          - openssl
+          - openssl-devel
+
+      kernel-rt-core:
+        description: This package is not in Fedora (yet), but we want it here.
+        requires:
+          - bash
+          - systemd-udev
+          - coreutils
+          - dracut
+          - linux-firmware
+          - systemd
+        buildrequires:
+          - kmod
+          - patch
+          - bash
+          - coreutils
+          - tar
+          - git
+          - which
+          - bzip2
+          - xz
+          - findutils
+          - gzip
+          - m4
+          - perl-interpreter
+          - perl-Carp
+          - perl-devel
+          - perl-generators
+          - make
+          - diffutils
+          - gawk
+          - gcc
+          - binutils
+          - redhat-rpm-config
+          - hmaccalc
+          - python3-devel
+          - net-tools
+          - hostname
+          - bc
+          - bison
+          - flex
+          - elfutils-devel
+          - dwarves
+          - openssl
+          - openssl-devel
+
+      kernel-rt-modules:
+        description: This package is not in Fedora (yet), but we want it here.
+        requires:
+          - bash
+          - systemd-udev
+          - coreutils
+          - dracut
+          - linux-firmware
+          - systemd
+        buildrequires:
+          - kmod
+          - patch
+          - bash
+          - coreutils
+          - tar
+          - git
+          - which
+          - bzip2
+          - xz
+          - findutils
+          - gzip
+          - m4
+          - perl-interpreter
+          - perl-Carp
+          - perl-devel
+          - perl-generators
+          - make
+          - diffutils
+          - gawk
+          - gcc
+          - binutils
+          - redhat-rpm-config
+          - hmaccalc
+          - python3-devel
+          - net-tools
+          - hostname
+          - bc
+          - bison
+          - flex
+          - elfutils-devel
+          - dwarves
+          - openssl
+          - openssl-devel
+
+      kernel-rt-modules-extra:
+        description: This package is not in Fedora (yet), but we want it here.
+        requires:
+          - bash
+          - systemd-udev
+          - coreutils
+          - dracut
+          - linux-firmware
+          - systemd
+        buildrequires:
+          - kmod
+          - patch
+          - bash
+          - coreutils
+          - tar
+          - git
+          - which
+          - bzip2
+          - xz
+          - findutils
+          - gzip
+          - m4
+          - perl-interpreter
+          - perl-Carp
+          - perl-devel
+          - perl-generators
+          - make
+          - diffutils
+          - gawk
+          - gcc
+          - binutils
+          - redhat-rpm-config
+          - hmaccalc
+          - python3-devel
+          - net-tools
+          - hostname
+          - bc
+          - bison
+          - flex
+          - elfutils-devel
+          - dwarves
+          - openssl
+          - openssl-devel
+      
+      kernel-rt-kvm:
+        description: This package is not in Fedora (yet), but we want it here.
+        requires:
+          - bash
+          - systemd-udev
+          - coreutils
+          - dracut
+          - linux-firmware
+          - systemd
+        buildrequires:
+          - kmod
+          - patch
+          - bash
+          - coreutils
+          - tar
+          - git
+          - which
+          - bzip2
+          - xz
+          - findutils
+          - gzip
+          - m4
+          - perl-interpreter
+          - perl-Carp
+          - perl-devel
+          - perl-generators
+          - make
+          - diffutils
+          - gawk
+          - gcc
+          - binutils
+          - redhat-rpm-config
+          - hmaccalc
+          - python3-devel
+          - net-tools
+          - hostname
+          - bc
+          - bison
+          - flex
+          - elfutils-devel
+          - dwarves
+          - openssl
+          - openssl-devel

--- a/configs/sst_kernel_rats-kernel-rt-develdebug.yaml
+++ b/configs/sst_kernel_rats-kernel-rt-develdebug.yaml
@@ -4,11 +4,100 @@ data:
     name: kernel-rt devel/debug
     description: Kernel RT packages used for devel/debug
     maintainer: sst_kernel_rats
-    packages:
-        - kernel-rt-debuginfo
-        - kernel-rt-devel
+    packages: []
     labels:
         - eln
     arch_packages:
         x86_64:
             - kernel-rt-debuginfo-common-x86_64
+
+    package_placeholders:
+      kernel-rt-debuginfo:
+        description: This package is not in Fedora (yet), but we want it here.
+        requires:
+          - bash
+          - systemd-udev
+          - coreutils
+          - dracut
+          - linux-firmware
+          - systemd
+        buildrequires:
+          - kmod
+          - patch
+          - bash
+          - coreutils
+          - tar
+          - git
+          - which
+          - bzip2
+          - xz
+          - findutils
+          - gzip
+          - m4
+          - perl-interpreter
+          - perl-Carp
+          - perl-devel
+          - perl-generators
+          - make
+          - diffutils
+          - gawk
+          - gcc
+          - binutils
+          - redhat-rpm-config
+          - hmaccalc
+          - python3-devel
+          - net-tools
+          - hostname
+          - bc
+          - bison
+          - flex
+          - elfutils-devel
+          - dwarves
+          - openssl
+          - openssl-devel
+          - rpm-build
+          - elfutils
+
+      kernel-rt-devel:
+        description: This package is not in Fedora (yet), but we want it here.
+        requires:
+          - bash
+          - systemd-udev
+          - coreutils
+          - dracut
+          - linux-firmware
+          - systemd
+        buildrequires:
+          - kmod
+          - patch
+          - bash
+          - coreutils
+          - tar
+          - git
+          - which
+          - bzip2
+          - xz
+          - findutils
+          - gzip
+          - m4
+          - perl-interpreter
+          - perl-Carp
+          - perl-devel
+          - perl-generators
+          - make
+          - diffutils
+          - gawk
+          - gcc
+          - binutils
+          - redhat-rpm-config
+          - hmaccalc
+          - python3-devel
+          - net-tools
+          - hostname
+          - bc
+          - bison
+          - flex
+          - elfutils-devel
+          - dwarves
+          - openssl
+          - openssl-devel


### PR DESCRIPTION
Use package_placeholders to specify details of kernel-rt packages
that are not yet in fedora.

Signed-off-by: Juri Lelli <juri.lelli@redhat.com>