### PR TITLE
Add hesiod placeholder

### DIFF
--- a/sst_identity_management-hesiod.yaml
+++ b/sst_identity_management-hesiod.yaml
@@ -1,0 +1,19 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+    name: Hesiod
+    description: Compat packages for the Hesiod system
+    maintainer: sst_identity_management
+
+    labels:
+        - eln
+
+    package_placeholders:
+        compat-hesiod:
+            description: The Hesiod naming service
+            requires: []
+            buildrequires:
+                - autoconf
+                - automake
+                - libtool
+                - libidn-devel


### PR DESCRIPTION
Hesiod is not present in Fedora, and is marked deprecated in RHEL.  Accordingly, the binary package is called compat-hesiod.  It might be worth double-checking I got the source vs. binary distinction right in the yaml.