### PR TITLE
Fix the typo in hunspell workload and rename filename

### DIFF
--- a/configs/sst_i18n-hunspell-dictionaries.yaml
+++ b/configs/sst_i18n-hunspell-dictionaries.yaml
@@ -82,7 +82,7 @@ data:
   - hunspell-nds
   - hunspell-ne
   - hunspell-nl
-  - hunspell-no
+  - hunspell-nn
   - hunspell-nr
   - hunspell-nso
   - hunspell-ny


### PR DESCRIPTION
This will fix typo in the workload and thus the package list error.