### PR TITLE
Update sst_desktop(_applications) workflows

### DIFF
--- a/configs/sst_desktop-totem.yaml
+++ b/configs/sst_desktop-totem.yaml
@@ -7,7 +7,6 @@ data:
 
   packages:
   - totem
-  - totem-nautilus
 
   labels:
   - eln

--- a/configs/sst_desktop_applications-gnome-photos.yaml
+++ b/configs/sst_desktop_applications-gnome-photos.yaml
@@ -8,6 +8,7 @@ data:
   packages:
   - gnome-photos
   - gnome-photos-tests
+  - exiv2
 
   labels:
   - eln

--- a/configs/sst_desktop_applications-qt5.yaml
+++ b/configs/sst_desktop_applications-qt5.yaml
@@ -7,12 +7,71 @@ data:
 
   packages:
   - adwaita-qt
+  - qgnomeplatform
   - qt5
   - qt5-doc
+  - qt5-rpm-macros
+  - qt5-srpm-macros
+  - qt5-qt3d
+  - qt5-qt3d-examples
+  - qt5-qtbase
+  - qt5-qtbase-common
+  - qt5-qtbase-examples
+  - qt5-qtbase-gui
+  - qt5-qtbase-mysql
+  - qt5-qtbase-odbc
+  - qt5-qtbase-postgresql
+  - qt5-qtbase-static
   - qt5-qtcanvas3d
+  - qt5-qtcanvas3d-examples
+  - qt5-qtconnectivity
+  - qt5-qtconnectivity-examples
+  - qt5-qtdeclarative
+  - qt5-qtdeclarative-examples
+  - qt5-qtdeclarative-static
+  - qt5-qtdoc
+  - qt5-qtgraphicaleffects
+  - qt5-qtimageformats
+  - qt5-qtlocation
+  - qt5-qtlocation-examples
+  - qt5-qtmultimedia
+  - qt5-qtmultimedia-examples
+  - qt5-qtquickcontrols
+  - qt5-qtquickcontrols-examples
+  - qt5-qtquickcontrols2
+  - qt5-qtquickcontrols2-examples
+  - qt5-qtscript
+  - qt5-qtscript-examples
+  - qt5-qtsensors
+  - qt5-qtsensors-examples
   - qt5-qtserialbus
+  - qt5-qtserialbus-examples
+  - qt5-qtserialport
+  - qt5-qtserialport-examples
+  - qt5-qtsvg
+  - qt5-qtsvg-examples
+  - qt5-assistant
+  - qt5-designer
+  - qt5-doctools
+  - qt5-linguist
+  - qt5-qdbusviewer
+  - qt5-qttools
+  - qt5-qttools-common
+  - qt5-qttools-examples
+  - qt5-qttools-libs-designer
+  - qt5-qttools-libs-designercomponents
+  - qt5-qttools-libs-help
+  - qt5-qttools-static
   - qt5-qttranslations
-  - qgnomeplatform
+  - qt5-qtwayland
+  - qt5-qtwayland-examples
+  - qt5-qtwebchannel
+  - qt5-qtwebchannel-examples
+  - qt5-qtwebsockets
+  - qt5-qtwebsockets-examples
+  - qt5-qtx11extras
+  - qt5-qtxmlpatterns
+  - qt5-qtxmlpatterns-examples
 
   labels:
   - eln


### PR DESCRIPTION
* Remove a totem subpackage that doesn't exist anymore
* Explicitly require exiv2 from GNOME Photos workflow
* Be explicit about all the required Qt 5 packages