### PR TITLE
Fix the TigerVNC workflow

### DIFF
--- a/configs/sst_desktop_applications-tigervnc.yaml
+++ b/configs/sst_desktop_applications-tigervnc.yaml
@@ -7,7 +7,6 @@ data:
 
   packages:
   - tigervnc
-  - tigervnc-selinux
   - tigervnc-server
   - tigervnc-server-module
 


### PR DESCRIPTION
The tigervnc-selinux doesn't exist yet on Fedora, so we had to create
a package_placeholder entry, but I forget to remove it from the packages
section.