### PR TITLE
Extend criu workload to include crit

### DIFF
--- a/configs/sst_kernel_tps-criu.yaml
+++ b/configs/sst_kernel_tps-criu.yaml
@@ -6,5 +6,6 @@ data:
   maintainer: sst_kernel_tps
   packages:
   - criu
+  - crit
   labels:
   - eln


### PR DESCRIPTION
crit is used to analyze CRIU image files