### PR TITLE
rasdaemon: list every supported architecture

### DIFF
--- a/configs/sst_kernel_ft-rasdaemon.yaml
+++ b/configs/sst_kernel_ft-rasdaemon.yaml
@@ -5,8 +5,7 @@ data:
   description: Utility to receive RAS error tracings
   maintainer: sst_kernel_ft
 
-  packages:
-  - rasdaemon
+  packages: []
 
   labels:      # <-- Please leave
   - eln        #     this unchanged.
@@ -18,3 +17,16 @@ data:
   #           - arch-specific-package1   # <-- The list of binary RPM packages
   #               - arch-specific-package1   #     goes here.
   #
+  arch_packages:
+      x86_64:
+          - rasdaemon
+          - rasdaemon-debuginfo
+          - rasdaemon-debugsource
+      aarch64:
+          - rasdaemon
+          - rasdaemon-debuginfo
+          - rasdaemon-debugsource
+      ppc64le:
+          - rasdaemon
+          - rasdaemon-debuginfo
+          - rasdaemon-debugsource


### PR DESCRIPTION
Since ExclusiveArch in the RPM isn't being used.

Signed-off-by: Aristeu Rozanski <arozansk@redhat.com>