### PR TITLE
Update coreos definition to fix resolver errors.

### DIFF
--- a/configs/sst_coreos.yaml
+++ b/configs/sst_coreos.yaml
@@ -13,7 +13,6 @@ data:
    - afterburn
    - afterburn-dracut
    - coreos-installer
-   - cri-o
    - ignition
    - runc
    - ssh-key-dir
@@ -28,7 +27,7 @@ data:
    - podman
    - rpm-ostree
    - skopeo
-   - systemd-containerd
+   - systemd-container
    - toolbox
 
   labels:


### PR DESCRIPTION
Remove `cri-o` since that is provided via OpenShift.
Fixed the `systemd-container` requirement.