### PR TITLE
FAST: Update the content set definitions for Platform Storage and Filesystems

### DIFF
--- a/configs/sst_filesystems-userspace.yaml
+++ b/configs/sst_filesystems-userspace.yaml
@@ -33,7 +33,6 @@ data:
     - pam_cifscreds
     - rpcbind
     - rpcgen
-    - rpcsvc-proto
     - rpcsvc-proto-devel
     - system-storage-manager
     - xfsdump

--- a/configs/sst_platform_storage-packages.yaml
+++ b/configs/sst_platform_storage-packages.yaml
@@ -43,8 +43,6 @@ data:
     - iscsi-initiator-utils-iscsiuio
     - isns-utils
     - isns-utils-libs
-    - libopeniscsiusr
-    - libopeniscsiusr-devel
     - python3-iscsi-initiator-utils
 
       # fcoe offload

--- a/configs/sst_platform_storage-packages.yaml
+++ b/configs/sst_platform_storage-packages.yaml
@@ -90,7 +90,6 @@ data:
     - libblockdev-nvdimm
     - libblockdev-part
     - libblockdev-plugins-all
-    - libblockdev-s390 (s390x)
     - libblockdev-swap
     - libblockdev-tools
     - libblockdev-utils
@@ -124,39 +123,11 @@ data:
     # - peripety
     #
 
+  placeholder_packages:
+    pmreorder:
+      description: This package is only available in RHEL.
+
   arch_packages:
-    aarch64:
-      - daxio
-      - libpmem
-      - libpmem-debug
-      - libpmem-devel
-      - libpmemblk
-      - libpmemblk-debug
-      - libpmemblk-devel
-      - libpmemlog
-      - libpmemlog-debug
-      - libpmemlog-devel
-      - libpmemobj
-      - libpmemobj++-devel
-      - libpmemobj++-doc
-      - libpmemobj-debug
-      - libpmemobj-devel
-      - libpmempool
-      - libpmempool-debug
-      - libpmempool-devel
-      - librpmem
-      - librpmem-debug
-      - librpmem-devel
-      - libvmem
-      - libvmem-debug
-      - libvmem-devel
-      - libvmmalloc
-      - libvmmalloc-debug
-      - libvmmalloc-devel
-      - pmdk-convert
-      - pmempool
-      - pmreorder
-      - rpmemd
     ppc64le:
       - daxio
       - libpmem
@@ -169,8 +140,6 @@ data:
       - libpmemlog-debug
       - libpmemlog-devel
       - libpmemobj
-      - libpmemobj++-devel
-      - libpmemobj++-doc
       - libpmemobj-debug
       - libpmemobj-devel
       - libpmempool
@@ -179,15 +148,7 @@ data:
       - librpmem
       - librpmem-debug
       - librpmem-devel
-      - libvmem
-      - libvmem-debug
-      - libvmem-devel
-      - libvmmalloc
-      - libvmmalloc-debug
-      - libvmmalloc-devel
-      - pmdk-convert
       - pmempool
-      - pmreorder
       - rpmemd
     x86_64:
       - daxio
@@ -211,16 +172,12 @@ data:
       - librpmem
       - librpmem-debug
       - librpmem-devel
-      - libvmem
-      - libvmem-debug
-      - libvmem-devel
-      - libvmmalloc
-      - libvmmalloc-debug
-      - libvmmalloc-devel
       - pmdk-convert
       - pmempool
-      - pmreorder
       - rpmemd
+
+    - s390x:
+      - libblockdev-s390
 
   labels:
   - eln


### PR DESCRIPTION
Adjusted the content set based on some errors in the platform storage workload [0] for ELN+Rawhide.

[0] https://tiny.distro.builders/workload-overview--sst_platform_storage-packages--repository-fedora-eln.html