### PR TITLE
SST_FILESYSTEMS: Adjusted content set definition for rpcsvc-proto.

### DIFF
--- a/configs/sst_filesystems-userspace.yaml
+++ b/configs/sst_filesystems-userspace.yaml
@@ -33,7 +33,6 @@ data:
     - pam_cifscreds
     - rpcbind
     - rpcgen
-    - rpcsvc-proto
     - rpcsvc-proto-devel
     - system-storage-manager
     - xfsdump


### PR DESCRIPTION
The rpcsvc-proto component does not provide a package with the basename of the
spec file (rpcsvc-proto).  This can be confirmed by looking at one of the
recent koji builds [0].

[0] https://koji.fedoraproject.org/koji/buildinfo?buildID=1577169