### PR TITLE
sst_kerenl_rats-perf: Limit rt-tests to x86_64 architecture

### DIFF
--- a/configs/sst_kernel_rats-perf.yaml
+++ b/configs/sst_kernel_rats-perf.yaml
@@ -20,6 +20,8 @@ data:
       - make
       - numactl-devel
       - python3-devel
+      limit_arches:
+      - x86_64
     rteval:
       description: This package is not in Fedora (yet), but we want it here.
       requires:


### PR DESCRIPTION
Limit the rt-tests suite to the x86_64 architecture.

Signed-off-by: John Kacur <jkacur@redhat.com>