### PR TITLE
Add pki-servlet-engine as a placeholder package

### DIFF
--- a/configs/sst_identity_management-freeipa-server.yaml
+++ b/configs/sst_identity_management-freeipa-server.yaml
@@ -10,3 +10,24 @@ data:
 
   labels:
   - eln
+
+  package_placeholders:
+    pki-servlet-engine:
+      description: This package provides a Tomcat-like servlet engine in RHEL 8+
+      requires:
+       - ant
+       - java-headless
+       - java-devel
+       - jpackage-utils
+       - procps
+       - shadow-utils
+       - chkconfig
+       - systemd-units
+       - coreutils
+      buildrequires:
+       - ant
+       - findutils
+       - java-devel
+       - jpackage-utils
+       - maven-local
+       - systemd-unnits


### PR DESCRIPTION
This package is only available in RHEL8+ and is present in Fedora under
the tomcat package name. Note that `tomcat` package is unwanted in RHEL8+.

See-Also: "tomcat in RHEL 9" with Adam Samalik, Tomas Tomecek, Coty
Sutherland, Troy Dawson, and myself.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---

@asamalik -- do I need to add this to _each_ IPA workload that requires Tomcat? Including `sst_identity_management-freeipa-server-full.yaml` and `sst_identity_management-freeipa-server-dc.yaml`? Or is once enough? 

/cc @csutherl @mkosek