### PR TITLE
Remove pexpect from HA package list

### DIFF
--- a/configs/sst_high_availability-userspace.yaml
+++ b/configs/sst_high_availability-userspace.yaml
@@ -93,7 +93,6 @@ data:
     - pacemaker-remote
     - pcs
     - pcs-snmp
-    - pexpect
     - python3-azure-sdk
     - python3-boto3
     - python3-botocore
@@ -196,7 +195,6 @@ data:
     - pacemaker-remote
     - pcs
     - pcs-snmp
-    - pexpect
     - python3-azure-sdk
     - python3-boto3
     - python3-botocore
@@ -298,7 +296,6 @@ data:
     - pacemaker-remote
     - pcs
     - pcs-snmp
-    - pexpect
     - python3-azure-sdk
     - python3-boto3
     - python3-botocore


### PR DESCRIPTION
Removing pexpect from HA package list as this will not be needed in RHEL 9 (the python3-pexpect package takes care of everything we need).