### PR TITLE
Remove nautilus-sendto

### DIFF
--- a/configs/sst_desktop_applications-nautilus.yaml
+++ b/configs/sst_desktop_applications-nautilus.yaml
@@ -15,7 +15,6 @@ data:
   - gvfs-mtp
   - gvfs-smb
   - nautilus
-  - nautilus-sendto
   - sushi
 
   labels:


### PR DESCRIPTION
It was removed from Fedora and dropped upstream - https://src.fedoraproject.org/rpms/nautilus-sendto/c/740c0bf3323bff3f62f4dfc3d2e996b1843e5295?branch=master