### PR TITLE
Replace glibc-headers-x86_64 with glibc-headers-x86

### DIFF
--- a/configs/sst_platform_tools-c++-development-full.yaml
+++ b/configs/sst_platform_tools-c++-development-full.yaml
@@ -18,7 +18,7 @@ data:
   - libgcc
   # Noarch header packages.
   - glibc-headers-s390
-  - glibc-headers-x86_64
+  - glibc-headers-x86
   # Full development includes additional packages:
   - glibc-utils
   - glibc-static

--- a/configs/sst_platform_tools-c++-development.yaml
+++ b/configs/sst_platform_tools-c++-development.yaml
@@ -18,7 +18,7 @@ data:
   - libgcc
   # Noarch header packages.
   - glibc-headers-s390
-  - glibc-headers-x86_64
+  - glibc-headers-x86
   # We support only the C/POSIX/C.UTF-8 locales.
   - glibc-minimal-langpack
 

--- a/configs/sst_platform_tools-c-development-full.yaml
+++ b/configs/sst_platform_tools-c-development-full.yaml
@@ -14,7 +14,7 @@ data:
   - glibc-devel
   # Noarch header packages.
   - glibc-headers-s390
-  - glibc-headers-x86_64
+  - glibc-headers-x86
   # Full development includes additional packages:
   - glibc-utils
   - glibc-static


### PR DESCRIPTION
Fixes commit eeb21a2ef008ba5353d14ef4c717864ca8fe1ce9 ("Add Platform
Tools C and C++ Runtime/Devel.") and commit
107af77ef635c4975283e09a41e5614b50356fe3 ("Add Platform Tools C
Runtime and Development.").

Suggested by Troy Dawson.