### PR TITLE
Update jmc ELN configuration to use stream 7

### DIFF
--- a/configs/sst_dotnet_java-jmc.yaml
+++ b/configs/sst_dotnet_java-jmc.yaml
@@ -6,7 +6,7 @@ data:
   maintainer: sst_dotnet_java
 
   modules_enable:
-  - jmc:latest
+  - jmc:7
   
   packages: []
 


### PR DESCRIPTION
Use stream 7 instead of latest. There were green koji builds for f33 and f34 tags so also hoping for the package set stuff to be seen now.

https://koji.fedoraproject.org/koji/buildinfo?buildID=1604357
https://koji.fedoraproject.org/koji/buildinfo?buildID=1604333