### PR TITLE
CS Infra Serv: moved geoipupdate to unwanted packages

### DIFF
--- a/configs/sst_cs_infra_services-geoip.yaml
+++ b/configs/sst_cs_infra_services-geoip.yaml
@@ -6,7 +6,6 @@ data:
   maintainer: sst_cs_infra_services
 
   packages:
-  - geoipupdate
   - geolite2-city
   - geolite2-country
   - libmaxminddb

--- a/configs/sst_cs_infra_services-unwanted.yaml
+++ b/configs/sst_cs_infra_services-unwanted.yaml
@@ -28,6 +28,8 @@ data:
   - GeoIP
   - GeoIP-data
   - GeoIP-devel
+  # geoipupdate
+  - geoipupdate
   # gsm
   - gsm-tools
   # gutenprint


### PR DESCRIPTION
The package is unusable without 3rd party subscription and it downlopads proprietary content. There is no way to properly test this and support

Signed-off-by: Tomas Hozza <thozza@redhat.com>