### PR TITLE
Add avahi and nss-mdns to printing workload

### DIFF
--- a/configs/sst_cs_infra_services-printing-stack.yaml
+++ b/configs/sst_cs_infra_services-printing-stack.yaml
@@ -30,6 +30,10 @@ data:
   - pnm2ppa
   # fonts
   - urw-base35-fonts
+  # service discovery, registering and sharing
+  - avahi
+  # resolving .local addresses
+  - nss-mdns
 
 
   labels:


### PR DESCRIPTION
CUPS and cups-browsed need avahi and nss-mdns for mDNS support.