### PR TITLE
Add edge packages

### DIFF
--- a/configs/sst_edge.yaml
+++ b/configs/sst_edge.yaml
@@ -1,0 +1,20 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: edge packages
+  description: Packages for edge usecases
+  maintainer: jwboyer
+
+  packages:
+  - greenboot
+  - greenboot-grub2
+  - greenboot-reboot
+  - greenboot-rpm-ostree-grub2
+  - greenboot-status
+  - ignition
+  - ostree
+  - rpm-ostree
+
+  labels:
+  - eln
+


### PR DESCRIPTION
ignition is speculative, but worth including for now.

ostree,rpm-ostree are really just to ensure another usecase is logged
for those packages