### PR TITLE
address resolver errors for perf and devel/debug workloads 

### DIFF
--- a/configs/sst_kernel_rats-kernel-rt-develdebug.yaml
+++ b/configs/sst_kernel_rats-kernel-rt-develdebug.yaml
@@ -239,6 +239,18 @@ data:
         limit_arches:
           - x86_64
 
+      kernel-rt-debuginfo-common-x86_64:
+        description: files used by kernel-rt-debuginfo
+        requires:
+          - bash
+          - systemd-udev
+          - coreutils
+          - dracut
+          - linux-firmware
+          - systemd
+        limit_arches:
+          - x86_64
+
       kernel-rt-debuginfo:
         description: This package is not in Fedora (yet), but we want it here.
         requires:
@@ -285,18 +297,6 @@ data:
           - openssl-devel
           - rpm-build
           - elfutils
-        limit_arches:
-          - x86_64
-
-      kernel-rt-debuginfo-common-x86_64:
-        description: files used by kernel-rt-debuginfo
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
         limit_arches:
           - x86_64
 

--- a/configs/sst_kernel_rats-perf.yaml
+++ b/configs/sst_kernel_rats-perf.yaml
@@ -35,7 +35,7 @@ data:
         - python3-dmidecode
         - rteval-loads
         - rteval-common
-        - systat
+        - sysstat
         - xz
         - bzip2
         - kernel-headers


### PR DESCRIPTION
Fix a package name typo
Try moving the kernel-rt-debuginfo-common-x86_64 block in an attempt to address resolver failure to see it