### PR TITLE
Do not explicitly list glibc-headers-x86, glibc-headers-s390

### DIFF
--- a/configs/sst_platform_tools-c++-development-full.yaml
+++ b/configs/sst_platform_tools-c++-development-full.yaml
@@ -16,9 +16,6 @@ data:
   - libstdc++
   - libstdc++-devel
   - libgcc
-  # Noarch header packages.
-  - glibc-headers-s390
-  - glibc-headers-x86
   # Full development includes additional packages:
   - glibc-utils
   - glibc-static

--- a/configs/sst_platform_tools-c++-development.yaml
+++ b/configs/sst_platform_tools-c++-development.yaml
@@ -16,9 +16,6 @@ data:
   - libstdc++
   - libstdc++-devel
   - libgcc
-  # Noarch header packages.
-  - glibc-headers-s390
-  - glibc-headers-x86
   # We support only the C/POSIX/C.UTF-8 locales.
   - glibc-minimal-langpack
 

--- a/configs/sst_platform_tools-c-development-full.yaml
+++ b/configs/sst_platform_tools-c-development-full.yaml
@@ -12,9 +12,6 @@ data:
   - glibc
   - glibc-common
   - glibc-devel
-  # Noarch header packages.
-  - glibc-headers-s390
-  - glibc-headers-x86
   # Full development includes additional packages:
   - glibc-utils
   - glibc-static

--- a/configs/sst_platform_tools-c-development.yaml
+++ b/configs/sst_platform_tools-c-development.yaml
@@ -12,9 +12,6 @@ data:
   - glibc
   - glibc-common
   - glibc-devel
-  # Noarch header packages.
-  - glibc-headers-x86
-  - glibc-headers-s390
   # We support only the C/POSIX/C.UTF-8 locales.
   - glibc-minimal-langpack
 


### PR DESCRIPTION
These packages are available on all architectures, but are only
installable on x86_64 and s390x.  On other architectures, they
have file conflicts with glibc-devel.


Red Hat GmbH, https://de.redhat.com/ , Registered seat: Grasbrunn,
Commercial register: Amtsgericht Muenchen, HRB 153243,
Managing Directors: Charles Cachera, Brian Klemm, Laurie Krebs, Michael O'Neill
