### PR TITLE
sst_kernel_rats-perf.yaml:  commented out requires defined in placeho…

### DIFF
--- a/configs/sst_kernel_rats-perf.yaml
+++ b/configs/sst_kernel_rats-perf.yaml
@@ -33,8 +33,6 @@ data:
         - python3-ethtool
         - python3-lxml
         - python3-dmidecode
-        - rteval-loads
-        - rteval-common
         - sysstat
         - xz
         - bzip2
@@ -49,6 +47,10 @@ data:
         - make
         - openssl
         - openssl-devel
+#   commented out due to content resolver not liking requires in the
+#   placeholder section
+#        - rteval-loads
+#        - rteval-common
       buildrequires:
         - python3-devel
       limit_arches:


### PR DESCRIPTION
…lder

rteval-loads and rteval-common are in the placeholder section and thats
a problem for the content resolver. Comment out for now

Signed-off-by: Clark Williams <williams@redhat.com>