### PR TITLE
arch_portfolio updates

### DIFF
--- a/configs/sst_arch_portfolio.yaml
+++ b/configs/sst_arch_portfolio.yaml
@@ -3,10 +3,10 @@ version: 1
 data:
   name: arch-portfolio
   description: Packages for architecture support
-  maintainer: jwboyer
+  maintainer: sst_arch_portfolio
 
   packages:
-  - openssl-ibmpkcs
+  - openssl-ibmpkcs11
 
   arch_packages:
     ppc64le:


### PR DESCRIPTION
set the maintainer to sst_arch_portfolio and add the missing 11
to openssl-ibmpkcs as the package is called openssl-ibmpkcs11

Signed-off-by: Dennis Gilmore <dennis@ausil.us>