### PR TITLE
remove non-existant s390utils-cmsfs package

### DIFF
--- a/configs/sst_arch_portfolio.yaml
+++ b/configs/sst_arch_portfolio.yaml
@@ -28,7 +28,6 @@ data:
     - openssl-ibmca
     - s390utils
     - s390utils-base
-    - s390utils-cmsfs
     - s390utils-cmsfs-fuse
     - s390utils-cpacfstatsd
     - s390utils-cpuplugd


### PR DESCRIPTION
s390utils-cmsfs does not exist so remove it from being required on s390x

Signed-off-by: Dennis Gilmore <dennis@ausil.us>