### PR TITLE
Add missing packages to SELinux workloads

### DIFF
--- a/configs/sst_security_selinux-base.yaml
+++ b/configs/sst_security_selinux-base.yaml
@@ -12,10 +12,12 @@ data:
   - libsemanage
   - policycoreutils
   - policycoreutils-python-utils
+  - policycoreutils-restorecond
   - mcstrans
   - selinux-policy-targeted
   - selinux-policy-mls
   - selinux-policy-sandbox
+  - selinux-policy-doc
 
   labels:
   - eln

--- a/configs/sst_security_selinux-base.yaml
+++ b/configs/sst_security_selinux-base.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: SELinux - Base
   description: A base set for SELinux policy management
-  maintainer: sst_platform_security
+  maintainer: sst_security_selinux
 
   packages:
   - libsepol

--- a/configs/sst_security_selinux-devel.yaml
+++ b/configs/sst_security_selinux-devel.yaml
@@ -6,10 +6,12 @@ data:
   maintainer: sst_security_selinux
 
   packages:
+  - libsepol-static
   - libsepol-devel
   - libselinux-devel
-  - libsemanage-devel
   - python3-libselinux
+  - libselinux-ruby
+  - libsemanage-devel
   - python3-libsemanage
   - python3-policycoreutils
 

--- a/configs/sst_security_selinux-devel.yaml
+++ b/configs/sst_security_selinux-devel.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: SELinux devel
   description: A development packages
-  maintainer: sst_platform_security
+  maintainer: sst_security_selinux
 
   packages:
   - libsepol-devel

--- a/configs/sst_security_selinux-tools.yaml
+++ b/configs/sst_security_selinux-tools.yaml
@@ -8,13 +8,16 @@ data:
   packages:
   - policycoreutils-devel
   - policycoreutils-gui
+  - policycoreutils-sandbox
   - checkpolicy
+  - setools
   - setools-console
   - setools-console-analyses
   - setools-gui
   - selinux-policy-devel
   - udica
   - setroubleshoot
+  - netlabel_tools
 
   labels:
   - eln

--- a/configs/sst_security_selinux-tools.yaml
+++ b/configs/sst_security_selinux-tools.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: SELinux tools
   description: A development tools for SELinux
-  maintainer: sst_platform_security
+  maintainer: sst_security_selinux
 
   packages:
   - policycoreutils-devel


### PR DESCRIPTION
And also rename the maintainer to sst_security_selinux

Please let me know when this change is propagated so I can re-check the diff between rhel8 and this.