### PR TITLE
Update jmc package sets with explicit listing of tycho and eclipse

### DIFF
--- a/configs/sst_dotnet_java-jmc.yaml
+++ b/configs/sst_dotnet_java-jmc.yaml
@@ -14,5 +14,7 @@ data:
     x86_64:
     - jmc
     - jmc-core
+    - eclipse-pde
+    - tycho
   labels:
   - eln

--- a/configs/sst_dotnet_java-unwanted.yaml
+++ b/configs/sst_dotnet_java-unwanted.yaml
@@ -8,8 +8,6 @@ data:
   - eln
 
   unwanted_packages:
-  # No Eclipse planned for RHEL 9, so seems little point in maintaining ecj, plus current deps don't need it
-  - ecj
   # RHEL should only get explicitly versioned JDKs (e.g. java-17-openjdk), not the rolling java-latest-openjdk
   - java-latest-openjdk
   # Oracle dropped deployment tool support with JDK 10 (March 2018), we shouldn't support it for the RHEL 9 lifecycle


### PR DESCRIPTION
From checking the resolved contents, the build dependency on tycho and eclipse was not caught. This updates the content set to include them. Eclipse will need ecj so that is removed from the unwanted packages.