### PR TITLE
sst_rhgs-unwanted: remove glusterfs RPMs from ELN

### DIFF
--- a/configs/sst_rhgs-unwanted.yaml
+++ b/configs/sst_rhgs-unwanted.yaml
@@ -1,0 +1,36 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: glusterfs_storage-unwanted
+  description: Unwanted glusterfs_storage packages
+  maintainer: kkeithle
+
+  unwanted_packages:
+  - glusterfs
+  - glusterfs-cli
+  - glusterfs-client-xlators
+  - glusterfs-cloudsync-plugins
+  - glusterfs-events
+  - glusterfs-extra-xlators
+  - glusterfs-fuse
+  - glusterfs-ganesha
+  - glusterfs-geo-replication
+  - glusterfs-server
+  - glusterfs-thin-arbiter
+  - glusterfs-resource-agents
+  - libgfapi-devel
+  - libgfapi0
+  - libgfchangelog-devel
+  - libgfchangelog0
+  - libgfrpc-devel
+  - libgfrpc0
+  - libxdr-devel
+  - libxdr0
+  - libglusterd0
+  - libglusterfs-devel
+  - libglusterfs0
+  - python3-gluster
+
+  labels:
+  - eln
+


### PR DESCRIPTION
Resolution of where glusterfs libs and -devel packages come from
in RHEL 9 is required.

Josh Boyer and I have been having a discusion on the hallway track.
This is intended to surface the issue.