### PR TITLE
Mention package name instead of rpm provides for dhclient

### DIFF
--- a/configs/sst_networking-management-core.yaml
+++ b/configs/sst_networking-management-core.yaml
@@ -7,7 +7,7 @@ data:
     NetworkManager and related tools.
   maintainer: sst_networking
   packages:
-  - dhclient
+  - dhcp-client
   - dnsmasq
   - iproute
   - NetworkManager

--- a/configs/sst_networking-management-desktop.yaml
+++ b/configs/sst_networking-management-desktop.yaml
@@ -9,7 +9,7 @@ data:
   packages:
   # Core
   - iproute
-  - dhclient
+  - dhcp-client
   - dnsmasq
   - NetworkManager
   - NetworkManager-tui

--- a/configs/sst_networking-management-devel.yaml
+++ b/configs/sst_networking-management-devel.yaml
@@ -7,7 +7,7 @@ data:
   packages:
   # Core
   - iproute
-  - dhclient
+  - dhcp-client
   - dnsmasq
   - NetworkManager
   - NetworkManager-tui

--- a/configs/sst_networking-management-server.yaml
+++ b/configs/sst_networking-management-server.yaml
@@ -10,7 +10,7 @@ data:
   packages:
   # Core
   - iproute
-  - dhclient
+  - dhcp-client
   - dnsmasq
   - NetworkManager
   - NetworkManager-tui


### PR DESCRIPTION
This content resolver is meant to list binary rpm package names instead,
so s/dhclient/dhcp-client/

Signed-off-by: Marcelo Ricardo Leitner <mleitner@redhat.com>

@cathay4t @thom311 