### PR TITLE
fast-packet-processing: Move all packages under arches.

### DIFF
--- a/configs/sst_networking-fast-packet-processing.yaml
+++ b/configs/sst_networking-fast-packet-processing.yaml
@@ -6,29 +6,46 @@ data:
     A set of libraries, drivers and tools required for configuration
     and fast packet processing.
   maintainer: sst_networking
-  packages:
-  - driverctl
-  - dpdk-doc
-  - tuned
-  - tuned-profiles-nfv
-  - tuned-profiles-nfv-guest
-  - tuned-profiles-nfv-host
-  - tuned-profiles-realtime
-  - tuned-profiles-cpu-partitioning
+
+  packages: []
 
   arch_packages:
     aarch64:
       - dpdk
       - dpdk-tools
       - dpdk-devel
+      - driverctl
+      - dpdk-doc
+      - tuned
+      - tuned-profiles-nfv
+      - tuned-profiles-nfv-guest
+      - tuned-profiles-nfv-host
+      - tuned-profiles-realtime
+      - tuned-profiles-cpu-partitioning
     ppc64le:
       - dpdk
       - dpdk-tools
       - dpdk-devel
+      - driverctl
+      - dpdk-doc
+      - tuned
+      - tuned-profiles-nfv
+      - tuned-profiles-nfv-guest
+      - tuned-profiles-nfv-host
+      - tuned-profiles-realtime
+      - tuned-profiles-cpu-partitioning
     x86_64:
       - dpdk
       - dpdk-tools
       - dpdk-devel
+      - driverctl
+      - dpdk-doc
+      - tuned
+      - tuned-profiles-nfv
+      - tuned-profiles-nfv-guest
+      - tuned-profiles-nfv-host
+      - tuned-profiles-realtime
+      - tuned-profiles-cpu-partitioning
 
   labels:
   - eln


### PR DESCRIPTION
The workload is only supported in three arches, so
move all packages under them to avoid problems with
noarch packages not available on unsupported arches.

Signed-off-by: Flavio Leitner <fbl@redhat.com>