### PR TITLE
configs/sst_kernel_tps-microcode.yaml: make microcode_ctl package x86_64-only

### DIFF
--- a/configs/sst_kernel_tps-microcode.yaml
+++ b/configs/sst_kernel_tps-microcode.yaml
@@ -5,8 +5,9 @@ data:
   description: Tools to update CPU microcode
   maintainer: sst_kernel_tps
 
-  packages:
-  - microcode_ctl
+  arch_packages:
+    x86_64:
+    - microcode_ctl
 
   labels:
   - eln


### PR DESCRIPTION
It is ridiculous it cannot be pulled from any other content set
definition that already exists.

Signed-off-by: Eugene Syromiatnikov <esyr@redhat.com>