### PR TITLE
Update the maintainer field to be the SST name

### DIFF
--- a/configs/sst_networking-firewall-tools.yaml
+++ b/configs/sst_networking-firewall-tools.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: firewall tools
   description: tools necessary to administrate linux firewalls
-  maintainer: egarver
+  maintainer: sst_networking
 
   labels:
   - eln

--- a/configs/sst_networking-firewall-unwanted.yaml
+++ b/configs/sst_networking-firewall-unwanted.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Unwanted firewalling packages
   description: Packages we do not want to ship for firewalling because they're unmaintained or broken.
-  maintainer: egarver
+  maintainer: sst_networking
 
   labels:
   - eln


### PR DESCRIPTION
As per the documentation (like in the Cheat Sheet screenshot), it should
be the SST name, so that the workloads show up in places such as [1].

1.https://tiny.distro.builders/maintainer--sst_networking.html

Signed-off-by: Marcelo Ricardo Leitner <mleitner@redhat.com>

@erig0 