### PR TITLE
sst_virtualization: Update filename and remove module definition

### DIFF
--- a/configs/sst_virtualization-all.yaml
+++ b/configs/sst_virtualization-all.yaml
@@ -5,9 +5,6 @@ data:
   description: Userspace agents and tools that enable virtualization capabilities on RHEL
   maintainer: sst_virtualization
 
-  modules_enable:
-  - virt:rhel
-
   packages:
   - amtterm
   - augeas


### PR DESCRIPTION
As virt is not a module in Fedora, remove the line that enables the
virt module and update the filename for sst_virtualization to '_all'
as this file contains all Virt packages which will later be split
into BaseOS and AppStream

Signed-off-by: Yash Mankad <ymankad@redhat.com>