### PR TITLE
Update sst_kernel_tps-tracing workload

### DIFF
--- a/configs/sst_kernel_tps-tracing.yaml
+++ b/configs/sst_kernel_tps-tracing.yaml
@@ -7,11 +7,20 @@ data:
 
   packages:
   - bcc
-  - bpftrace
   - perf
   - strace
   - trace-cmd
   - kernelshark
+
+  arch_packages:
+    aarch64:
+      - bpftrace
+    ppc64le:
+      - bpftrace
+    s390x:
+      - bpftrace
+    x86_64:
+      - bpftrace
 
   labels:
   - eln


### PR DESCRIPTION
The bpftrace package does not exist on armv7hl