### PR TITLE
RDMA stack architecture specific packages

### DIFF
--- a/configs/sst_nic_rdma-appstream-arch.yaml
+++ b/configs/sst_nic_rdma-appstream-arch.yaml
@@ -1,0 +1,43 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: RDMA Stack arch_packages
+  description: Mellanox packages do not support s390x
+  maintainer: sst_nic_rdma
+
+  packages: []
+
+  arch_packages:
+    aarch64:
+      - mstflint
+      - libvma
+      - libvma-utils
+      - libvma-devel
+      - ucx
+      - ucx-cma
+      - ucx-devel
+      - ucx-ib
+      - ucx-rdmacm
+    ppc64le:
+      - mstflint
+      - libvma
+      - libvma-utils
+      - libvma-devel
+      - ucx
+      - ucx-cma
+      - ucx-devel
+      - ucx-ib
+      - ucx-rdmacm
+    x86_64:
+      - mstflint
+      - libvma
+      - libvma-utils
+      - libvma-devel
+      - ucx
+      - ucx-cma
+      - ucx-devel
+      - ucx-ib
+      - ucx-rdmacm
+
+  labels:
+  - eln

--- a/configs/sst_nic_rdma-appstream.yaml
+++ b/configs/sst_nic_rdma-appstream.yaml
@@ -9,7 +9,6 @@ data:
   - libfabric-devel
   - fabtests
   - opensm-devel
-  - mstflint
   - qperf
   - openmpi
   - openmpi-devel
@@ -21,13 +20,5 @@ data:
   - mpich-devel
   - mpich-doc
   - python3-mpich
-  - libvma
-  - libvma-utils
-  - libvma-devel
-  - ucx
-  - ucx-cma
-  - ucx-devel
-  - ucx-ib
-  - ucx-rdmacm
   labels:
   - eln


### PR DESCRIPTION
Confirmed with Mellanox that mstflint, libvma, and ucx do not
support s390x.

Signed-off-by: Honggang Li <honli@redhat.com>