### PR TITLE
Add OpenJDK subpackages (including listing unshipped debug packages in unwanted)

### DIFF
--- a/configs/sst_dotnet_java-java.yaml
+++ b/configs/sst_dotnet_java-java.yaml
@@ -7,11 +7,29 @@ data:
 
   packages:
   - java-1.8.0-openjdk
+  - java-1.8.0-openjdk-accessibility
+  - java-1.8.0-openjdk-demo
+  - java-1.8.0-openjdk-devel
+  - java-1.8.0-openjdk-headless
+  - java-1.8.0-openjdk-javadoc
+  - java-1.8.0-openjdk-javadoc-zip
+  - java-1.8.0-openjdk-src
   - java-11-openjdk
+  - java-11-openjdk-demo
+  - java-11-openjdk-devel
+  - java-11-openjdk-headless
+  - java-11-openjdk-javadoc
+  - java-11-openjdk-javadoc-zip
+  - java-11-openjdk-jmods
+  - java-11-openjdk-src
+  - java-11-openjdk-static-libs
+  - copy-jdk-configs
   # With Nashorn gone in newer JDKs, we need a JS engine
   - rhino
   # Core tool for JDK support work
   - byteman
+  - byteman-bmunit
+  - byteman-javadoc
 
   labels:
   - eln

--- a/configs/sst_dotnet_java-unwanted.yaml
+++ b/configs/sst_dotnet_java-unwanted.yaml
@@ -12,3 +12,30 @@ data:
   - java-latest-openjdk
   # Oracle dropped deployment tool support with JDK 10 (March 2018), we shouldn't support it for the RHEL 9 lifecycle
   - icedtea-web
+  # Debug packages should be built but not shipped to customers
+  - java-1.8.0-openjdk-slowdebug
+  - java-1.8.0-openjdk-accessibility-slowdebug
+  - java-1.8.0-openjdk-demo-slowdebug
+  - java-1.8.0-openjdk-devel-slowdebug
+  - java-1.8.0-openjdk-headless-slowdebug
+  - java-1.8.0-openjdk-src-slowdebug
+  - java-1.8.0-openjdk-fastdebug
+  - java-1.8.0-openjdk-accessibility-fastdebug
+  - java-1.8.0-openjdk-demo-fastdebug
+  - java-1.8.0-openjdk-devel-fastdebug
+  - java-1.8.0-openjdk-headless-fastdebug
+  - java-1.8.0-openjdk-src-fastdebug
+  - java-11-openjdk-slowdebug
+  - java-11-openjdk-demo-slowdebug
+  - java-11-openjdk-devel-slowdebug
+  - java-11-openjdk-headless-slowdebug
+  - java-11-openjdk-jmods-slowdebug
+  - java-11-openjdk-src-slowdebug
+  - java-11-openjdk-static-libs-slowdebug
+  - java-11-openjdk-fastdebug
+  - java-11-openjdk-demo-fastdebug
+  - java-11-openjdk-devel-fastdebug
+  - java-11-openjdk-headless-fastdebug
+  - java-11-openjdk-jmods-fastdebug
+  - java-11-openjdk-src-fastdebug
+  - java-11-openjdk-static-libs-fastdebug


### PR DESCRIPTION
Our original submissions only listed the packages by spec filename, and didn't include any subpackages produced by the same spec file. This adds the missing subpackages for java-1.8.0-openjdk, java-11-openjdk & byteman.
We also add the *-slowdebug & *-fastdebug packages to the unwanted list. Although these will be built, these should not be part of the package listings, as they are only used on demand from specific customer cases.