### PR TITLE
sst_nic_rdma: no RDMA on armv7hl

### DIFF
--- a/configs/sst_nic_rdma-appstream.yaml
+++ b/configs/sst_nic_rdma-appstream.yaml
@@ -8,8 +8,6 @@ data:
   packages:
   - libfabric-devel
   - fabtests
-  - opensm-devel
-  - qperf
   - openmpi
   - openmpi-devel
   - openmpi-java
@@ -22,3 +20,17 @@ data:
   - python3-mpich
   labels:
   - eln
+  arch_packages:
+    # not armv7hl
+    aarch64:
+      - opensm-devel
+      - qperf
+    ppc64le:
+      - opensm-devel
+      - qperf
+    s390x:
+      - opensm-devel
+      - qperf
+    x86_64:
+      - opensm-devel
+      - qperf

--- a/configs/sst_nic_rdma-baseos.yaml
+++ b/configs/sst_nic_rdma-baseos.yaml
@@ -6,21 +6,74 @@ data:
   maintainer: sst_nic_rdma
 
   packages:
-  - libibverbs
-  - libibverbs-utils
-  - librdmacm
-  - librdmacm-utils
-  - rdma-core
-  - ibacm
-  - infiniband-diags
-  - iwpmd
-  - libibumad
-  - srp_daemon
-  - rdma-core-devel
-  - python3-pyverbs
   - libfabric
-  - opensm
-  - opensm-libs
-  - perftest
+
   labels:
   - eln
+
+  arch_packages:
+    # not armv7hl
+    aarch64:
+      - libibverbs
+      - libibverbs-utils
+      - librdmacm
+      - librdmacm-utils
+      - rdma-core
+      - ibacm
+      - infiniband-diags
+      - iwpmd
+      - libibumad
+      - srp_daemon
+      - rdma-core-devel
+      - python3-pyverbs
+      - opensm
+      - opensm-libs
+      - perftest
+    ppc64le:
+      - libibverbs
+      - libibverbs-utils
+      - librdmacm
+      - librdmacm-utils
+      - rdma-core
+      - ibacm
+      - infiniband-diags
+      - iwpmd
+      - libibumad
+      - srp_daemon
+      - rdma-core-devel
+      - python3-pyverbs
+      - opensm
+      - opensm-libs
+      - perftest
+    s390x:
+      - libibverbs
+      - libibverbs-utils
+      - librdmacm
+      - librdmacm-utils
+      - rdma-core
+      - ibacm
+      - infiniband-diags
+      - iwpmd
+      - libibumad
+      - srp_daemon
+      - rdma-core-devel
+      - python3-pyverbs
+      - opensm
+      - opensm-libs
+      - perftest
+    x86_64:
+      - libibverbs
+      - libibverbs-utils
+      - librdmacm
+      - librdmacm-utils
+      - rdma-core
+      - ibacm
+      - infiniband-diags
+      - iwpmd
+      - libibumad
+      - srp_daemon
+      - rdma-core-devel
+      - python3-pyverbs
+      - opensm
+      - opensm-libs
+      - perftest


### PR DESCRIPTION
rdma-core has ExcludeArch: %{arm}