### PR TITLE
sst_kernel_rats-kernel-rt: Remove unwanted tuned-profiles-nfv-host-bin

### DIFF
--- a/configs/sst_kernel_rats-kernel-rt-base.yaml
+++ b/configs/sst_kernel_rats-kernel-rt-base.yaml
@@ -270,12 +270,3 @@ data:
           - man
         limit_arches:
           - x86_64
-
-      tuned-profiles-nfv-host-bin:
-        description: This package is not in Fedora (yet), but we want it here.
-        buildrequires:
-          - gcc
-          - make
-          - glibc
-        limit_arches:
-          - x86_64


### PR DESCRIPTION
This package is marked as unwanted in el9 content set and we do not want
to ship it to customers.

Signed-off-by: Juri Lelli <juri.lelli@redhat.com>