### PR TITLE
Builds for Firefox and Thunderbird are now enabled on s390x in Fedora

### DIFF
--- a/configs/sst_desktop_applications-firefox.yaml
+++ b/configs/sst_desktop_applications-firefox.yaml
@@ -5,28 +5,14 @@ data:
   description: Default web browser for Workstation
   maintainer: sst_desktop_applications
 
-  packages: []
+  packages:
+  - firefox
 
   labels:
   - eln
 
-  arch_packages:
-    aarch64:
-      - firefox
-    ppc64le:
-      - firefox
-    x86_64:
-      - firefox
-
   package_placeholders:
     redhat-bookmarks:
       description: This package contains the default bookmarks for Red Hat Enterprise Linux
-      requires: []
-      buildrequires: []
-    # Create a separate placeholder for s390x's Firefox as it's not build in Fedora
-    firefox:
-      description: Default web browser for Workstation
-      limit_arches:
-        - s390x
       requires: []
       buildrequires: []

--- a/configs/sst_desktop_applications-thunderbird.yaml
+++ b/configs/sst_desktop_applications-thunderbird.yaml
@@ -5,24 +5,8 @@ data:
   description: Default e-mail client for Workstation
   maintainer: sst_desktop_applications
 
-  packages: []
+  packages:
+  - thunderbird
 
   labels:
   - eln
-
-  arch_packages:
-    aarch64:
-      - thunderbird
-    ppc64le:
-      - thunderbird
-    x86_64:
-      - thunderbird
-
-  package_placeholders:
-    # Create a separate placeholder for s390x's Thunderbird as it's not build in Fedora
-    thunderbird:
-      description: Default e-mail client for Workstation
-      limit_arches:
-        - s390x
-      requires: []
-      buildrequires: []


### PR DESCRIPTION
See https://src.fedoraproject.org/rpms/firefox/c/8be51c4c516e8c1c244097307d4e28ae089f7fcc?branch=master and
https://src.fedoraproject.org/rpms/thunderbird/c/ba38d87f3a0110ed0ec4fe0b837a1857feaa8484?branch=master.