### PR TITLE
Adding py3c-devel and py3c-doc to a workload for CRB

### DIFF
--- a/configs/sst_cs_apps-python-crb.yaml
+++ b/configs/sst_cs_apps-python-crb.yaml
@@ -18,6 +18,8 @@ data:
   - python3-sphinx
   - python3-wheel
   - python3-pytest
+  - py3c-devel
+  - py3c-doc
 
   labels:
   - eln


### PR DESCRIPTION
New packages in RHEL8 that should carry over to RHEL9 as well.