### PR TITLE
Virt SST: more minor updates to the Virtualization Content Set

### DIFF
--- a/configs/sst_virtualization-all.yaml
+++ b/configs/sst_virtualization-all.yaml
@@ -41,7 +41,7 @@ data:
   - ocaml-xml-light
   - osinfo-db
   - osinfo-db-tools
-  - phodav
+  - libphodav
   - po4a
   - python-augeas
   - python3-libvirt

--- a/configs/sst_virtualization-all.yaml
+++ b/configs/sst_virtualization-all.yaml
@@ -10,20 +10,18 @@ data:
   - augeas
   - dtc
   - fuse-sshfs
-  - gtk-vnc
+  - gtk-vnc2
   - hexedit
   - hivex
   - icoutils
   - ipxe-roms-qemu
   - libguestfs
-  - libguestfs-winsupport
   - libiscsi
   - libnbd
   - libosinfo
   - libvirt
   - libvirt-dbus
   - libvirt-glib
-  - libvirt-python
   - mdevctl
   - nbdkit
   - netcf
@@ -46,28 +44,37 @@ data:
   - phodav
   - po4a
   - python-augeas
+  - python3-libvirt
   - qemu-guest-agent
   - qemu-kvm
-  - rhevm-guest-agent
   - seabios
   - sgabios
   - spice-html5
   - supermin
   - vhostmd
-  - virt-manager
+  - virt-install
   - virt-top
   - virt-what
-  - xorg-x11-drv-qxl
 
   labels:
   - eln
 
   arch_packages:
     x86_64:
+    - edk2-ovmf
     - virt-v2v
     - virt-p2v
-    - edk2-ovmf
+    - xorg-x11-drv-qxl
     ppc64le:
     - SLOF
+    - xorg-x11-drv-qxl
     aarch64:
     - edk2-aarch64
+    - xorg-x11-drv-qxl
+
+    libguestfs-winsupport:
+      description: Add support for Windows guests to virt-v2v and virt-p2v
+      requires: []
+      buildrequires: []
+      limit_arches:
+      - x86_64

--- a/configs/sst_virtualization-exclusion.yaml
+++ b/configs/sst_virtualization-exclusion.yaml
@@ -14,6 +14,7 @@ data:
   - ocaml-camlp4
   - OVMF
   - perl-Sys-Virt
+  - rhevm-guest-agent
   - spice-xpi
   - virt-rhel-module
 


### PR DESCRIPTION
- Updating package names to match Fedora
- Moving xorg-x11 package to it's supported arches
- Moving the rhevm-guest-agent package to the exclusion list
- Adding a package_placeholder for libguestfs-winsupport 

Signed-off-by: Yash Mankad <ymankad@redhat.com>