### PR TITLE
sst_kernel_rats-kernel-rt: Remove bpftool from unwanted list

### DIFF
--- a/configs/sst_kernel_rats-kernel-rt-unwanted.yaml
+++ b/configs/sst_kernel_rats-kernel-rt-unwanted.yaml
@@ -8,7 +8,6 @@ data:
   unwanted_packages:
   - kernel-rt-modules-internal
   - kernel-rt-selftests-internal
-  - bpftool
 
   labels:
   - eln


### PR DESCRIPTION
kernel-rt uses bpftool built by kernel, but it still wants the package.

Signed-off-by: Juri Lelli <juri.lelli@redhat.com>