### PR TITLE
Remove the polkit-gnome from requirements

### DIFF
--- a/configs/sst_desktop-gnome-desktop.yaml
+++ b/configs/sst_desktop-gnome-desktop.yaml
@@ -33,7 +33,6 @@ data:
   - gnome-shell-extension-windowsNavigator
   - gnome-shell-extension-workspace-indicator
   - gnome-tweaks
-  - polkit-gnome
   - tracker
   - xdg-user-dirs-gtk
 


### PR DESCRIPTION
We actually do have it in the unwanted list as the polkit dialog is being provided by GNOME Shell nowadays.