### PR TITLE
Adjust libcroco

### DIFF
--- a/configs/sst_openstack.yaml
+++ b/configs/sst_openstack.yaml
@@ -45,7 +45,6 @@ data:
   - libknet1-plugins-all
   - libcacard
   - libcgroup
-  - libcroco
   - liberation-fonts
   - libev
   - libguestfs
@@ -115,6 +114,16 @@ data:
     - spice-server
     ppc64le:
     - dpdk
+
+  package_placeholders:
+    libcroco:
+      description: CSS2 parsing and manipulation library for GNOME
+      requires:
+      - libxml2
+      - glib2
+      buildrequires:
+      - libxml2-devel
+      - glib2-devel
 
   labels:
   - eln


### PR DESCRIPTION
This is retired in Rawhide, so even though there is an ELN build
it doesn't get pulled into a compose and doesn't show up in
Content Resolver