### PR TITLE
Remove cyrus-imapd-vzic package

### DIFF
--- a/configs/sst_cs_infra_services-mda.yaml
+++ b/configs/sst_cs_infra_services-mda.yaml
@@ -8,7 +8,6 @@ data:
   packages:
   - cyrus-imapd
   - cyrus-imapd-utils
-  - cyrus-imapd-vzic
   - procmail
 
   labels:


### PR DESCRIPTION
Cyrus-imapd-vzic is deprecated with cyrus-timezones package and not
built anymore. Cyrus-timezones is weak dependency of the main package.