### PR TITLE
Add cyrus-timezones to MDA content definition

### DIFF
--- a/configs/sst_cs_infra_services-mda.yaml
+++ b/configs/sst_cs_infra_services-mda.yaml
@@ -7,7 +7,7 @@ data:
 
   packages:
   - cyrus-imapd
-  - cyrus-imapd-utils
+  - cyrus-timezones
   - procmail
 
   labels:


### PR DESCRIPTION
Cyrus-timezones replaces vzic timezones compiler.
cyrus-imapd-utils depends on main package and main package depends on
utils subpackage thus it's enough to specify main package only.