### PR TITLE
Not make setserial and cdrdao part of s390x, drop opal-firmware and m…

### DIFF
--- a/configs/sst_cs_system_management-depsonly.yaml
+++ b/configs/sst_cs_system_management-depsonly.yaml
@@ -10,7 +10,6 @@ data:
   - cdparanoia-libs
   - cdparanoia-devel
   - cdparanoia
-  - cdrdao
   - libusal-devel
   - libusal
   - genisoimage
@@ -57,6 +56,17 @@ data:
   - sparsehash-devel
   - tesseract
   - tesseract-devel
+
+arch_packages:
+    #cdrdao not supported on s390x
+    aarch64:
+    - cdrdao
+    i686:
+    - cdrdao
+    x86_64:
+    - cdrdao
+    ppc64le:
+    - cdrdao
 
   labels:
   - eln

--- a/configs/sst_cs_system_management-sys-management.yaml
+++ b/configs/sst_cs_system_management-sys-management.yaml
@@ -61,7 +61,6 @@ data:
   - librabbitmq-devel
   - librabbitmq
   - librabbitmq-tools
-  - opal-firmware
   - opencryptoki-devel
   - opencryptoki-icsftok
   - opencryptoki-swtok
@@ -73,8 +72,6 @@ data:
   - openhpi-devel
   - patch
   - patchutils
-  - rhel-system-roles-sap
-  - setserial
   - symlinks
   - teckit
   - teckit-devel
@@ -123,5 +120,24 @@ data:
   - netpbm-devel
   - python3-jmespath
 
+  arch_packages:
+    #setserial not supported on s390x
+    aarch64:
+    - setserial
+    i686:
+    - setserial
+    x86_64:
+    - setserial
+    ppc64le:
+    - setserial
+
+
+  package_placeholders:
+    rhel-system-roles-sap:
+      description: system roles for SAP
+      requires: []
+      limit_arches:
+        - x86_64
+        - ppc64le
   labels:
   - eln


### PR DESCRIPTION
Not make setserial and cdrdao part of s390x, drop opal-firmware and make rhel-system-roles-sap package placeholder to fix failures in Core Services System management SST.