### PR TITLE
Add jsoncpp and rhash to the unwanted list.

### DIFF
--- a/configs/sst_platform_tools-unwanted.yaml
+++ b/configs/sst_platform_tools-unwanted.yaml
@@ -36,3 +36,6 @@ data:
   - compat-libpthread-nonshared
   # Remove nscd in favour of sssd.
   - nscd
+  # Remove jsoncpp and rhash which are not used by cmake.
+  - jsoncpp
+  - rhash


### PR DESCRIPTION
The only user of jsoncpp and rhash is CMake and we fix that up
so we don't need these packages.  Therefore we place them on the
unwanted list.