### PR TITLE
Explicitly mark libcgroup as unwanted

### DIFF
--- a/configs/sst_cs_apps-unwanted-libcgroup.yaml
+++ b/configs/sst_cs_apps-unwanted-libcgroup.yaml
@@ -1,0 +1,12 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Unwanted packages for libcgroup
+  description: libcgroup doesn't support cgroupv2 and has been effectively dead for a long time
+  maintainer: sst_cs_apps
+
+  unwanted_packages:
+  - libcgroup
+
+  labels:
+  - eln


### PR DESCRIPTION
libcgroup doesn't support cgroupv2 and has been effectively dead for a long time.

However, I can see it being listed as [openstack dependency](https://github.com/minimization/content-resolver-input/blob/01838f97eb7c542ac500349b3a0eca00f229d70d/configs/sst_openstack.yaml#L47). @jwboyer Do you happen to know why is it there/where it comes from?