### PR TITLE
Fix sst_security_special_projects SST name

### DIFF
--- a/configs/sst_security_special_projects-aide.yaml
+++ b/configs/sst_security_special_projects-aide.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: AIDE
   description: Advanced Intrusion Detection Environment.
-  maintainer: sst_security_special
+  maintainer: sst_security_special_projects
 
   packages:
   - aide

--- a/configs/sst_security_special_projects-application-whitelisting.yaml
+++ b/configs/sst_security_special_projects-application-whitelisting.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Application Whitelisting
   description: Packages providing application whitelisting functionality
-  maintainer: sst_security_special
+  maintainer: sst_security_special_projects
 
   packages:
   - fapolicyd

--- a/configs/sst_security_special_projects-audit.yaml
+++ b/configs/sst_security_special_projects-audit.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: AUDIT
   description: The user space utilities for storing and searching of audit events.
-  maintainer: sst_security_special
+  maintainer: sst_security_special_projects
 
   packages:
   - audit

--- a/configs/sst_security_special_projects-libcap.yaml
+++ b/configs/sst_security_special_projects-libcap.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: LIBCAP
   description: A library for getting and setting POSIX capabilities.
-  maintainer: sst_security_special
+  maintainer: sst_security_special_projects
 
   packages:
   - libcap

--- a/configs/sst_security_special_projects-nbde.yal
+++ b/configs/sst_security_special_projects-nbde.yal
@@ -3,7 +3,7 @@ version: 1
 data:
   name: NBDE
   description: Network-Bound Disc Encryption
-  maintainer: sst_security_special
+  maintainer: sst_security_special_projects
 
   packages:
   - clevis

--- a/configs/sst_security_special_projects-rsyslog.yaml
+++ b/configs/sst_security_special_projects-rsyslog.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Rsyslog
   description: Popular logging daemon
-  maintainer: sst_security_special
+  maintainer: sst_security_special_projects
 
   packages:
   - rsyslog

--- a/configs/sst_security_special_projects-scrub.yaml
+++ b/configs/sst_security_special_projects-scrub.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: SCRUB
   description: Scrub writes patterns on files or disk devices to make retrieving the data more difficult.
-  maintainer: sst_security_special
+  maintainer: sst_security_special_projects
 
   packages:
   - scrub

--- a/configs/sst_security_special_projects-sudo.yaml
+++ b/configs/sst_security_special_projects-sudo.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Sudo
   description: Sudo allows a system administrator to give certain users/groups well defined set of priviledges.
-  maintainer: sst_security_special
+  maintainer: sst_security_special_projects
 
   packages:
   - sudo

--- a/configs/sst_security_special_projects-usbguard.yaml
+++ b/configs/sst_security_special_projects-usbguard.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: USBGuard
   description: Enforcing USB security policy
-  maintainer: sst_security_special
+  maintainer: sst_security_special_projects
 
   packages:
   - catch1-devel


### PR DESCRIPTION
Correct full name of Security Special Projects is
sst_security_special_projects not sst_security_special.

CC @radosroka 