### PR TITLE
Add git-lfs placeholder

### DIFF
--- a/configs/sst_cs_apps-scm.yaml
+++ b/configs/sst_cs_apps-scm.yaml
@@ -10,7 +10,17 @@ data:
   - git-daemon
   - git-gui
   - gitk
-  - git-lfs
 
   labels:
   - eln
+
+  package_placeholders:
+    git-lfs:
+      description: Git extension for versioning large files
+      requires:
+        - git-core
+
+      buildrequires:
+        - perl-Digest-SHA
+        - perl-Test-Harness
+        - git


### PR DESCRIPTION
Git-lfs pulls a lot of golang dependencies that we want to bundle in RHEL 9.
Making a conditional in Fedora package would make spec file larger and worse readable.
We decided to make git-lfs a "package placeholder" and pull only dependencies that we want.