### PR TITLE
Explicitly mark rtl-sdr{,-devel} as unwanted

### DIFF
--- a/configs/sst_kernel_tps-unwanted.yaml
+++ b/configs/sst_kernel_tps-unwanted.yaml
@@ -1,0 +1,13 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Unwanted Packages - sst_kernel_tps
+  description: Packages not shipping in RHEL 9
+  maintainer: sst_kernel_tps (vdronov for rtl-sdr*)
+
+  unwanted_packages:
+  - rtl-sdr
+  - rtl-sdr-devel
+
+  labels:
+  - eln


### PR DESCRIPTION
It was decided that we do not really need rtl-sdr* in the RHEL9, since it is
a software for quite a narrow range of hardware (Realtek RTL2832 based DVB-T
dongles). Currenly only rng-tools need rtl-sdr* and this dependency is being
removed.