### PR TITLE
Add SID to Platform Storage Supported Packages

### DIFF
--- a/configs/sst_platform_storage-packages.yaml
+++ b/configs/sst_platform_storage-packages.yaml
@@ -73,8 +73,20 @@ data:
     - mdadm
     - sanlock
     - userspace-rcu
-    # sid is pending https://fedoraproject.org/wiki/Changes/SID
-    # - sid
+    # SID and its sub-packages
+    - sid                                                                                 
+    - sid-base-libs                                                                       
+    - sid-base-libs-devel                                                                 
+    - sid-iface-libs                                                                      
+    - sid-iface-libs-devel                                                                
+    - sid-log-libs                                                                        
+    - sid-log-libs-devel                                                                  
+    - sid-mod-block-blkid                                                                 
+    - sid-mod-block-dm-mpath                                                              
+    - sid-mod-dummies                                                                     
+    - sid-resource-libs                                                                   
+    - sid-resource-libs-devel                                                             
+    - sid-tools    
 
     # Storage Management
     - hdparm


### PR DESCRIPTION
SID package with its sub-packages are new addition to F33+ (https://fedoraproject.org/wiki/Changes/SID) and planned for RHEL9+. Please, add these packages to the list.