### PR TITLE
XDP: Move from sst_networking to sst_kernel_tps

### DIFF
--- a/configs/sst_kernel_tps-xdp.yaml
+++ b/configs/sst_kernel_tps-xdp.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: XDP
   description: Tools to support XDP
-  maintainer: sst_networking
+  maintainer: sst_kernel_tps
 
   packages:
   - xdp-tools


### PR DESCRIPTION
I will still be maintaining xdp-tools going forward, so let's move it into
sst_kernel_tps (but keep it as its own workload).

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>


----

#