### PR TITLE
sst_kernel_rats-tpm: Add tpm2-pkcs11 packages

### DIFF
--- a/configs/sst_kernel_rats-tpm.yaml
+++ b/configs/sst_kernel_rats-tpm.yaml
@@ -17,6 +17,8 @@ data:
   - tpm2-tss
   - tpm2-tss-devel
   - tpm2-tools
+  - tpm2-pkcs11
+  - tpm2-pkcs11-tools
   # needed for gating tests
   - tpm2-abrmd
   - tpm2-abrmd-devel


### PR DESCRIPTION
Already have a request to add tpm2-pkcs11 to rhel8, so go ahead
and get it into rhel9.

Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>