### PR TITLE
Remove from `rubygems` unwanted.

### DIFF
--- a/configs/unwanted-eln-packages.yaml
+++ b/configs/unwanted-eln-packages.yaml
@@ -44,10 +44,8 @@ data:
   - xen-runtime
   - xen-doc
 
-  # Vít Ondruch: rubygems is subpackage of ruby package and therefore
-  # the independent version is not needed. rubypick is not needed and
-  # there is %bcond_without to disable it
-  - rubygems
+  # Vít Ondruch: rubypick is not needed and there is %bcond_without
+  # to disable it
   - rubypick
 
   # Dalibor Pospisil:


### PR DESCRIPTION
In reality, we want to have `rubygems`, which is subpackage of `ruby`. It just needs different treatment then mark it unwanted. This is related to #165.