### PR TITLE
Use rubygem-tilt placeholder to reduce Ruby dependency chain.

### DIFF
--- a/configs/sst_cs_apps-ruby.yaml
+++ b/configs/sst_cs_apps-ruby.yaml
@@ -11,3 +11,13 @@ data:
 
   labels:
   - eln
+
+  package_placeholders:
+    rubygem-tilt:
+      description: Generic interface to multiple Ruby template engines
+      requires:
+        - ruby(rubygems)
+
+      buildrequires:
+        - rubygem(minitest)
+        - /usr/bin/ronn


### PR DESCRIPTION
Tilt has gazillion dependencies and what is worser, half of them are circular. Luckily, they test just possible runtime dependencies which will be unused at the end. They are enabled on Fedora, just because they can be enabled. Therefore cut them off to reduce the Ruby dependency chain.

Also note that when dependency is not available, the tests are just skipped.