### PR TITLE
Add `Provides: rubygem(tilt)` to rubygem-tilt placeholder.

### DIFF
--- a/configs/sst_cs_apps-ruby.yaml
+++ b/configs/sst_cs_apps-ruby.yaml
@@ -15,6 +15,9 @@ data:
   package_placeholders:
     rubygem-tilt:
       description: Generic interface to multiple Ruby template engines
+      provides:
+        - rubygem(tilt)
+
       requires:
         - ruby(rubygems)
 


### PR DESCRIPTION
I hope this syntax is supported.

This is related to #386.