### PR TITLE
Virt SST: Update 'required' list and add RHEL-only package_placeholders

### DIFF
--- a/configs/sst_virtualization-all.yaml
+++ b/configs/sst_virtualization-all.yaml
@@ -14,27 +14,19 @@ data:
   - hexedit
   - hivex
   - ipxe-roms-qemu
-  - libguestfs
   - libiscsi
   - libnbd
   - libosinfo
   - libvirt
   - libvirt-dbus
   - libvirt-glib
+  - libguestfs-inspect-icons
   - mdevctl
-  - meson
-  - ninja-build
   - nbdkit
-  - netcf
-  - ocaml
-  - ocaml-libvirt
   - osinfo-db
   - osinfo-db-tools
-  - po4a
   - python-augeas
   - python3-libvirt
-  - qemu-guest-agent
-  - qemu-kvm
   - seabios
   - sgabios
   - supermin
@@ -49,7 +41,6 @@ data:
   arch_packages:
     x86_64:
     - edk2-ovmf
-    - virt-v2v
     - virt-p2v
     - xorg-x11-drv-qxl
     ppc64le:

--- a/configs/sst_virtualization-all.yaml
+++ b/configs/sst_virtualization-all.yaml
@@ -50,10 +50,178 @@ data:
     - edk2-aarch64
     - xorg-x11-drv-qxl
 
+  package_placeholders:
+    qemu-kvm:
+      description: QEMU is a machine emulator and virtualizer
+      requires:
+        - cyrus-sasl-lib
+        - device-mapper-multipath-libs
+        - edk2
+        - glib2
+        - glusterfs-api
+        - gnutls
+        - ipxe-roms-qemu
+        - libaio
+        - libcap-ng
+        - libcurl
+        - libepoxy
+        - libfdt
+        - libgcrypt
+        - libibverbs
+        - libiscsi
+        - libpmem
+        - libpng
+        - librados2
+        - librbd1
+        - librdmacm
+        - libseccomp
+        - libssh
+        - libusbx
+        - libxkbcommon
+        - lzo
+        - mesa-dri-drivers
+        - mesa-libEGL
+        - mesa-libgbm
+        - mesa-libGL
+        - numactl-libs
+        - pixman
+        - powerpc-utils
+        - python3
+        - seabios-bin
+        - seavgabios-bin
+        - sgabios-bin
+        - SLOF
+        - snappy
+        - spice-server
+        - usbredir
+        - zlib
+      buildrequires:
+        - binutils
+        - brlapi-devel
+        - check-devel
+        - cpp
+        - cyrus-sasl-devel
+        - device-mapper-multipath-devel
+        - diffutils
+        - glib2-devel
+        - glusterfs-api-devel
+        - glusterfs-devel
+        - gnutls-devel
+        - iasl
+        - libaio-devel
+        - libattr-devel
+        - libcacard-devel
+        - libcap-ng-devel
+        - libcap-ng-devel
+        - libcurl-devel
+        - libdrm-devel
+        - libepoxy-devel
+        - libfdt-devel
+        - libgcrypt-devel
+        - libiscsi-devel
+        - libpmem-devel
+        - libpng-devel
+        - librados-devel
+        - librbd-devel
+        - libseccomp-devel
+        - libssh-devel
+        - libtool
+        - libusbx-devel
+        - libuuid-devel
+        - libxkbcommon-devel
+        - lzo-devel snappy-devel
+        - meson
+        - ncurses-devel
+        - ninja-build
+        - nss-devel
+        - numactl-devel
+        - pciutils-devel
+        - perl-podlators
+        - perl-Test-Harness
+        - pixman-devel
+        - python3-devel
+        - python3-sphinx
+        - python3-sphinx
+        - rdma-core-devel
+        - rpm-build
+        - rsync
+        - spice-protocol
+        - spice-server-devel
+        - systemd-devel
+        - systemtap
+        - systemtap-sdt-devel
+        - texinfo
+        - texinfo
+        - usbredir-devel
+        - wget
+        - which
+        - zlib-devel
+      srpm: qemu-kvm
+    libguestfs:
+      description: libguestfs is a set of tools for accessing and modifying virtual machine (VM) disk images
+      requires:
+        - gdisk
+        - gfs2-utils
+        - hexedit
+        - hivex
+        - icoutils
+        - libconfig
+        - netpbm-progs
+        - parted
+        - perl-hivex
+        - squashfs-tools
+      buildrequires:
+        - gdisk
+        - gfs2-utils
+        - gjs
+        - gobject-introspection-devel
+        - hivex-devel
+        - icoutils
+        - libconfig-devel
+        - libvirt-daemon-kvm
+        - lua-devel
+        - netpbm-progs
+        - ocaml-findlib-devel
+        - ocaml-gettext-devel
+        - ocaml-hivex-devel
+        - ocaml-ocamldoc
+        - parted
+        - perl-Sys-Virt
+        - perl-hivex
+        - perl-libintl-perl
+        - po4a
+        - ruby-devel
+        - rubygem-rake
+        - rubygem-rdoc
+        - rubygem-test-unit
+        - squashfs-tools
+      srpm: libguestfs
+    virt-v2v:
+      description: Virt-v2v converts a single guest from a foreign hypervisor to run on KVM
+      requires:
+        - libguestfs
+        - libguestfs-winsupport
+        - mingw32-srvany
+        - nbdkit-curl-plugin
+        - nbdkit-python-plugin
+        - nbdkit-ssh-plugin
+        - nbdkit-vddk-plugin
+      buildrequires:
+        - libguestfs
+        - ocaml-fileutils-devel
+        - ocaml-findlib-devel
+        - ocaml-gettext-devel
+        - po4a
+      limit_arches:
+      - x86_64
+      srpm: virt-v2v
     libguestfs-winsupport:
       description: Add support for Windows guests to virt-v2v and virt-p2v
-      requires: []
+      requires:
+        - libguestfs
+        - libconfig
       buildrequires:
+        - libconfig-devel
         - mingw-gcc
         - mingw-binutils
         - mingw-filesystem
@@ -62,3 +230,4 @@ data:
         - mingw-srvany
       limit_arches:
       - x86_64
+      srpm: libguestfs-winsupport


### PR DESCRIPTION
Remove packages such as libguestfs, qemu-kvm, qemu-guest-agent and others that are packaged differently in RHEL v. Fedora ELN. Also, remove dependencies such as meson, ninja-build, ocaml that will be pulled in by other SRPMs.

And add 'package_placeholders' for qemu-kvm, libguestfs, virt-v2v, and update the definition for libguestfs-winsupport
