### PR TITLE
Add qt to unwanted packages

### DIFF
--- a/configs/sst_desktop_applications-unwanted.yaml
+++ b/configs/sst_desktop_applications-unwanted.yaml
@@ -26,6 +26,10 @@ data:
   - rarian
   - yajl
   - GConf2
+  # Only Qt5 will be part of RHEL 9
+  - qt
+  - PyQt4
+  # Don't include web engines that are basically unmaintained
   - qtwebkit
   - qt5-qtwebkit
   # As SPICE won't be part of RHEL 9, we will ship Boxes as a Flatpak based on RHEL 8 runtime


### PR DESCRIPTION
Put qt (version 4) to unwanted list as only qt5 will be in RHEL 9