### PR TITLE
tracker was replaced by tracker3

### DIFF
--- a/configs/sst_desktop-gnome-desktop.yaml
+++ b/configs/sst_desktop-gnome-desktop.yaml
@@ -36,7 +36,7 @@ data:
   - chrome-gnome-shell
   - low-memory-monitor
   - power-profiles-daemon
-  - tracker
+  - tracker3
   - uresourced
   - xdg-user-dirs-gtk
 

--- a/configs/sst_desktop-unwanted.yaml
+++ b/configs/sst_desktop-unwanted.yaml
@@ -61,5 +61,8 @@ data:
   - libbluray
   - libdmapsharing
   - libaec
+  # Replaced by tracker3
+  - tracker
+  - tracker-miners
   labels:
   - eln


### PR DESCRIPTION
Currently some packages still require tracker, but will be ported soon.