### PR TITLE
package libcmpiCppImpl0 conflicts with tog-pegasus-libs, split the wo…

### DIFF
--- a/configs/sst_cs_system_management-sys-management-sblim-cmpi-devel.yaml
+++ b/configs/sst_cs_system_management-sys-management-sblim-cmpi-devel.yaml
@@ -1,0 +1,13 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: sblim-cmpi-devel
+  description: SBLIM CMPI Provider Development Support
+  maintainer: sst_cs_system_management
+
+  packages:
+  - libcmpiCppImpl0
+  - sblim-cmpi-devel
+
+  labels:
+  - eln

--- a/configs/sst_cs_system_management-sys-management-tog-pegasus.yaml
+++ b/configs/sst_cs_system_management-sys-management-tog-pegasus.yaml
@@ -1,0 +1,14 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: tog-pegasus
+  description: OpenPegasus WBEM Services for Linux
+  maintainer: sst_cs_system_management
+
+  packages:
+  - tog-pegasus-devel
+  - tog-pegasus-libs
+  - tog-pegasus
+
+  labels:
+  - eln

--- a/configs/sst_cs_system_management-sys-management.yaml
+++ b/configs/sst_cs_system_management-sys-management.yaml
@@ -6,23 +6,17 @@ data:
   maintainer: sst_cs_system_management
 
   packages:
-
   - libwsman-devel
   - libwsman1
   - openwsman-server
   - sblim-cmpi-base
   - sblim-cmpi-base-devel
-  - libcmpiCppImpl0
-  - sblim-cmpi-devel
   - sblim-indication_helper
   - sblim-indication_helper-devel
   - sblim-sfcb
   - sblim-sfcc
   - sblim-sfcc-devel
   - sblim-wbemcli
-  - tog-pegasus-devel
-  - tog-pegasus-libs
-  - tog-pegasus
   - wsmancli
   - Xaw3d
   - Xaw3d-devel
@@ -131,7 +125,6 @@ data:
     ppc64le:
     - setserial
 
-
   package_placeholders:
     rhel-system-roles-sap:
       srpm: rhel-system-roles-sap
@@ -140,5 +133,6 @@ data:
       limit_arches:
         - x86_64
         - ppc64le
+
   labels:
   - eln


### PR DESCRIPTION
the workload failed because of package libcmpiCppImpl0 conflicts with tog-pegasus-libs.
   https://tiny.distro.builders/workload-overview--sst_cs_system_management-sys-management--repository-fedora-eln.html

I splitted the workloads so each is fully installable.