### PR TITLE
texlive-wasy2-ps and texlive-texconfig obsoleted in texlive-2020

### DIFF
--- a/configs/sst_cs_system_management-text-processing.yaml
+++ b/configs/sst_cs_system_management-text-processing.yaml
@@ -181,7 +181,6 @@ data:
   - texlive-realscripts
   - texlive-utopia
   - texlive-babel-english
-  - texlive-wasy2-ps
   - texlive-memoir
   - texlive-babel
   - texlive-etoolbox
@@ -340,7 +339,6 @@ data:
   - texlive-fixlatvian
   - texlive-ltxmisc
   - texlive-qstest
-  - texlive-texconfig
   - texlive-parallel
   - texlive-t2
   - texlive-rcs


### PR DESCRIPTION
tthe workload failed (https://tiny.distro.builders/workload-overview--sst_cs_system_management-text-processing--repository-fedora-eln.html)  because  texlive-wasy2-ps and texlive-texconfig are removed in texlive-2020 upstream.