### PR TITLE
Add tracer to the sst_cs_system_management-other workload

### DIFF
--- a/configs/sst_cs_system_management-other.yaml
+++ b/configs/sst_cs_system_management-other.yaml
@@ -26,6 +26,7 @@ data:
   - scotch
   - scotch-doc
   - bc
+  - tracer
 
   labels:
   - eln


### PR DESCRIPTION
AFAIK we want to add tracer only because of Cockpit so I am not
creating a separate workload but adding it here.