### PR TITLE
Add modulemd-tools to the sst_cs_system_management-other workload

### DIFF
--- a/configs/sst_cs_system_management-other.yaml
+++ b/configs/sst_cs_system_management-other.yaml
@@ -27,6 +27,7 @@ data:
   - scotch-doc
   - bc
   - tracer
+  - modulemd-tools
 
   labels:
   - eln


### PR DESCRIPTION
Adding the `modulemd-tools` package,
upstream is here https://github.com/rpm-software-management/modulemd-tools