### PR TITLE
Move pinentry to the rest of GPG packages in crypto team

### DIFF
--- a/configs/sst_rh_samba_storage.yaml
+++ b/configs/sst_rh_samba_storage.yaml
@@ -7,7 +7,6 @@ data:
 
   packages:
   - libedit
-  - pinentry
   - plotutils
 
   arch_packages:

--- a/configs/sst_security_crypto-gnupg.yaml
+++ b/configs/sst_security_crypto-gnupg.yaml
@@ -1,0 +1,19 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: GnuPG suite
+  description: Tools and libraries needed for GnuPG
+  maintainer: sst_security_crypto
+
+  packages:
+  - gnupg2
+  - libgpg-error
+  - libgcrypt
+  - libksba
+  - libassuan
+  - npth
+  - pinentry
+
+  labels:
+  - eln
+


### PR DESCRIPTION
This mostly summarizes list of dependencies of gnupg2 in RHEL, but also moves `pinentry` package from samba as agreed with Boris and Simo. Adding also @jwboyer as he is marked as a maintainer of the current samba "workload".