### PR TITLE
rubygem-bundler is wanted, while it is not wanted as independent package

### DIFF
--- a/configs/sst_cs_apps-unwanted-ruby.yaml
+++ b/configs/sst_cs_apps-unwanted-ruby.yaml
@@ -5,9 +5,10 @@ data:
   description: Packages we do not want to ship for Ruby
   maintainer: sst_cs_apps
 
-  unwanted_packages:
+  unwanted_source_packages:
   - rubygem-bundler
-  - rubygem-bundler-doc
+
+  unwanted_packages:
   - rubygem-rspec-its
   - rubygem-rspec-its-doc
   - rubypick


### PR DESCRIPTION
In ELN, we want only the rubygem-bundler which is build from ruby package, while in Fedora, there is also independent rubygem-bundler, which we don't want. It seems that content-resolver cannot make good enough distinction between these two. OTOH, independent rubygem-bundler is hopefully removed already, so we should be able to drop this.