### PR TITLE
Remove librhsm from sst_cs_software_management unwanted packages

### DIFF
--- a/configs/sst_cs_software_management-unwanted.yaml
+++ b/configs/sst_cs_software_management-unwanted.yaml
@@ -12,12 +12,6 @@ data:
   # drop drpm support from RHEL 9
   - drpm-devel
 
-  # replace with a subscription-manager plugin
-  - librhsm
-
-  # replace with a subscription-manager plugin
-  - librhsm-devel
-
   # we don't want to support LUA interpreter
   - lua
 


### PR DESCRIPTION
librhsm stays because it's not going to be merged with subscription-manager
plugins in the near feature.