### PR TITLE
Remove libuv from unwanted due to many bugs and issues (#1895872)

### DIFF
--- a/configs/sst_cs_apps-unwanted.yaml
+++ b/configs/sst_cs_apps-unwanted.yaml
@@ -6,7 +6,6 @@ data:
   maintainer: sst_cs_apps
 
   unwanted_packages:
-  - libuv
   - js-uglify
   - web-assets-devel
 


### PR DESCRIPTION
Since there were multiple bugs filed for missing libuv-devel in EL8, I suggest we include libuv and libuv-devel.

https://bugzilla.redhat.com/show_bug.cgi?id=1895872

@voxik @hhorak @jwboyer 