### PR TITLE
Remove python3-hawkey from sst_cs_software_management unwanted packages

### DIFF
--- a/configs/sst_cs_software_management-unwanted.yaml
+++ b/configs/sst_cs_software_management-unwanted.yaml
@@ -21,9 +21,6 @@ data:
   # don't ship static libs
   - popt-static
 
-  # replaced with python3-libdnf
-  - python3-hawkey
-
   # SysV init related, no longer needed because we have systemd
   - rpm-plugin-prioreset
 


### PR DESCRIPTION
python3-hawkey will be fully replaced with python3-libdnf
in the DNF 5 stack which has been postponed to the next release