### PR TITLE
Drop libcroco from the Openstack workload

### DIFF
--- a/configs/sst_openstack.yaml
+++ b/configs/sst_openstack.yaml
@@ -115,16 +115,5 @@ data:
     ppc64le:
     - dpdk
 
-  package_placeholders:
-    libcroco:
-      srpm: libcroco
-      description: CSS2 parsing and manipulation library for GNOME
-      requires:
-      - libxml2
-      - glib2
-      buildrequires:
-      - libxml2-devel
-      - glib2-devel
-
   labels:
   - eln


### PR DESCRIPTION
According to #rhos-delivery it might not be needed anymore