### PR TITLE
Add xapian-core to the list of packages for MDA workload

### DIFF
--- a/configs/sst_cs_infra_services-mda.yaml
+++ b/configs/sst_cs_infra_services-mda.yaml
@@ -9,6 +9,7 @@ data:
   - cyrus-imapd
   - cyrus-imapd-utils
   - cyrus-imapd-vzic
+  - xapian-core
   - procmail
 
   labels:


### PR DESCRIPTION
While cyrus-imapd has built-in search engine it's broken badly since 3.0 release
Xapian is standard search engine for this purposes and fully supported.