### PR TITLE
Add xapian-core to the MDA workload

### DIFF
--- a/configs/sst_cs_infra_services-mda.yaml
+++ b/configs/sst_cs_infra_services-mda.yaml
@@ -9,6 +9,7 @@ data:
   - cyrus-imapd
   - cyrus-timezones
   - procmail
+  - xapian-core
 
   labels:
   - eln


### PR DESCRIPTION
While cyrus-imapd has built-in index and search engine it's broken
badly since 3.0 release. Xapian is stable supported replacement