### PR TITLE
Drop hostname from the list of unwanted packages

### DIFF
--- a/configs/sst_cs_infra_services-base-os-packages.yaml
+++ b/configs/sst_cs_infra_services-base-os-packages.yaml
@@ -16,6 +16,7 @@ data:
   - ncurses-base
   - ncurses-term
   - setup
+  - hostname
 
   arch_packages:
     x86_64:

--- a/configs/sst_cs_infra_services-unwanted.yaml
+++ b/configs/sst_cs_infra_services-unwanted.yaml
@@ -35,8 +35,6 @@ data:
   # gutenprint
   - gutenprint-extras
   - gutenprint-plugin
-  # hostname
-  - hostname
   # hplip
   - hplip-gui
   # ldns


### PR DESCRIPTION
The initial plan was to deprecate hostname and replace it with
hostnamectl. In reallity hostnamectl is not drop-in replacement
and has few issues which block application from using it at early
stages (no dbus etc)