### PR TITLE
Drop avahi, nss-mdns from the printing stack

### DIFF
--- a/configs/sst_cs_infra_services-printing-stack.yaml
+++ b/configs/sst_cs_infra_services-printing-stack.yaml
@@ -30,9 +30,6 @@ data:
   - pnm2ppa
   # fonts
   - urw-base35-fonts
-  # resolving .local addresses
-  - nss-mdns
-
 
   labels:
   - eln

--- a/configs/sst_cs_infra_services-printing-stack.yaml
+++ b/configs/sst_cs_infra_services-printing-stack.yaml
@@ -30,8 +30,6 @@ data:
   - pnm2ppa
   # fonts
   - urw-base35-fonts
-  # service discovery, registering, sharing
-  - avahi
   # resolving .local addresses
   - nss-mdns
 


### PR DESCRIPTION
These are required by packages from within the printing stack, but not owned by this SST.