### PR TITLE
sst_cs_software_mgmt: bring Lua CLI back

### DIFF
--- a/configs/sst_cs_software_management-unwanted.yaml
+++ b/configs/sst_cs_software_management-unwanted.yaml
@@ -12,9 +12,6 @@ data:
   # drop drpm support from RHEL 9
   - drpm-devel
 
-  # we don't want to support LUA interpreter
-  - lua
-
   # don't ship static libs
   - lua-static
 


### PR DESCRIPTION
We decided to keep the "lua" binary package (the CLI interpreter) around
after all.  It's built from the same Lua SRPM that we already own (as an
embedded interpreter in RPM), so there's not much additional maintenance
burden associated with the CLI interpreter itself (which alone can be
quite useful).