### PR TITLE
usbredir is wanted

### DIFF
--- a/configs/sst_virtualization_spice-exclusion.yaml
+++ b/configs/sst_virtualization_spice-exclusion.yaml
@@ -16,9 +16,6 @@ data:
   - spice-gtk3-devel
   - spice-gtk3-vala
   - spice-protocol
-  - usbredir
-  - usbredir-devel
-  - usbredir-server
   - libcacard
   - libcacard-devel
   - spice-html5


### PR DESCRIPTION
The Virt team requested for usbredir to stay.

It already appears in sst_virtualization-all.yaml, so
just remove it from spice-exclusion.