### PR TITLE
add missing opal-prd into /sst_cs_system_management-sys-management

### DIFF
--- a/configs/sst_cs_system_management-sys-management.yaml
+++ b/configs/sst_cs_system_management-sys-management.yaml
@@ -124,6 +124,9 @@ data:
     - setserial
     ppc64le:
     - setserial
+    - opal-prd
+    - opal-utils
+    - opal-firmware
 
   package_placeholders:
     rhel-system-roles-sap:


### PR DESCRIPTION
opal-prd is missing in sst_cs_system_management-sys-management. It should be included so it can be built.
