### PR TITLE
Add a2ps as an unwanted package

### DIFF
--- a/configs/sst_cs_infra_services-unwanted.yaml
+++ b/configs/sst_cs_infra_services-unwanted.yaml
@@ -6,6 +6,8 @@ data:
   maintainer: sst_cs_infra_services
 
   unwanted_packages:
+  # a2ps
+  - a2ps
   # authd
   - authd
   # bind


### PR DESCRIPTION
a2ps is brought in by perl-Font-AFM package, because it needs a font from a2ps. perl-Font-AFM can skip the test and remove a2ps dependency or require a font from RHEL - see https://src.fedoraproject.org/rpms/perl-Font-AFM/pull-request/1 .