### PR TITLE
Drop tpm1.2 support

### DIFF
--- a/configs/sst_kernel_rats-tpm-exclusion.yaml
+++ b/configs/sst_kernel_rats-tpm-exclusion.yaml
@@ -7,6 +7,12 @@ data:
 
   unwanted_packages:
   - tpm-quote-tools
+  - trousers
+  - trousers-lib
+  - trousers-devel
+  - tpm-tools
+  - tpm-tools-pkcs11
+  - tpm-tools-devel
 
   labels:
   - eln

--- a/configs/sst_kernel_rats-tpm.yaml
+++ b/configs/sst_kernel_rats-tpm.yaml
@@ -6,12 +6,6 @@ data:
   maintainer: sst_kernel_rats
 
   packages:
-  - trousers
-  - trousers-lib
-  - trousers-devel
-  - tpm-tools
-  - tpm-tools-pkcs11
-  - tpm-tools-devel
   - tss2
   - tss2-devel
   - tpm2-tss


### PR DESCRIPTION
We do not plan to support TPM1.2 in RHEL9 so drop the userspace packages.

Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>