### PR TITLE
firewall: add iptables-nft

### DIFF
--- a/configs/sst_networking-firewall-tools.yaml
+++ b/configs/sst_networking-firewall-tools.yaml
@@ -20,5 +20,6 @@ data:
   - ipset
   - ipset-service
   - iptables
+  - iptables-nft
   - iptables-services
   - nftables


### PR DESCRIPTION
This is to hopefully avoid a superficial issue in content resolver in
which packages Require "ebtables", but that makes content resolver think
package "ebtables-legacy" is wanted. Package "iptables-nft" has a
Provides for "ebtables".