### PR TITLE
Add cups-printerapp

### DIFF
--- a/configs/sst_cs_infra_services-printing-stack.yaml
+++ b/configs/sst_cs_infra_services-printing-stack.yaml
@@ -12,6 +12,7 @@ data:
   - cups-filters
   - cups-ipptool
   - cups-lpd
+  - cups-printerapp
   - enscript
   - foomatic
   - foomatic-db


### PR DESCRIPTION
cups-printerapp contains the printer application for supporting older devices which needs a driver.