### PR TITLE
kernel_rats: python-schedutils not required

### DIFF
--- a/configs/sst_kernel_rats-perf.yaml
+++ b/configs/sst_kernel_rats-perf.yaml
@@ -30,7 +30,6 @@ data:
       srpm: rteval
       description: This package is not in Fedora (yet), but we want it here.
       requires:
-        - python3-schedutils
         - python3-ethtool
         - python3-lxml
         - python3-dmidecode

--- a/configs/sst_kernel_rats-tools.yaml
+++ b/configs/sst_kernel_rats-tools.yaml
@@ -6,7 +6,6 @@ data:
   maintainer: sst_kernel_rats
   packages:
   - tuna
-  - python3-schedutils
   - python3-linux-procfs
   labels:
   - eln


### PR DESCRIPTION
python-schedutils (python3-schedutils) is no longer required by
rteval and tuna so drop the dependency

Signed-off-by: John Kacur <jkacur@redhat.com>