### PR TITLE
printing-stack.yaml: don't require nss-mdns

### DIFF
--- a/configs/sst_cs_infra_services-printing-stack.yaml
+++ b/configs/sst_cs_infra_services-printing-stack.yaml
@@ -31,8 +31,6 @@ data:
   - pnm2ppa
   # fonts
   - urw-base35-fonts
-  # resolving .local addresses
-  - nss-mdns
 
 
   labels:


### PR DESCRIPTION
nss-mdns can be added during the life cycle, if the solution with systemd-resolved + Avahi doesn't work.