### PR TITLE
SST_HIGH_AVAILABILITY: Moved python3-clufter to unwanted.

### DIFF
--- a/configs/sst_high_availability-userspace-unwanted.yaml
+++ b/configs/sst_high_availability-userspace-unwanted.yaml
@@ -13,6 +13,7 @@ data:
   - clufter-lib-general
   - clufter-lib-pcs
   - jing-trang
+  - python3-clufter
 
   labels:
   - eln

--- a/configs/sst_high_availability-userspace.yaml
+++ b/configs/sst_high_availability-userspace.yaml
@@ -105,7 +105,6 @@ data:
     - python3-azure-sdk
     - python3-boto3
     - python3-botocore
-    - python3-clufter
     - python3-fasteners
     - python3-google-api-client
     - python3-httplib2
@@ -203,7 +202,6 @@ data:
     - python3-azure-sdk
     - python3-boto3
     - python3-botocore
-    - python3-clufter
     - python3-fasteners
     - python3-google-api-client
     - python3-httplib2
@@ -300,7 +298,6 @@ data:
     - python3-azure-sdk
     - python3-boto3
     - python3-botocore
-    - python3-clufter
     - python3-fasteners
     - python3-google-api-client
     - python3-httplib2


### PR DESCRIPTION
It turns out that we don't want to include python3-clufter.  This will also
resolve an open dependancy chain that was pulling in clufter-{bin,cli,common}
when they shouldn't be.