### PR TITLE
SPICE: do not pull phodav

### DIFF
--- a/configs/sst_virtualization_spice-exclusion.yaml
+++ b/configs/sst_virtualization_spice-exclusion.yaml
@@ -10,6 +10,8 @@ data:
   - spice-server-devel
   - spice-html5
   - spice-webdavd
+  - libphodav-devel
+  - libphodav
 
   - celt051
   - celt051-devel


### PR DESCRIPTION
In Fedora libphodav is required by spice-gtk.

This change may break spice-gtk build, until its spec file is modified.