### PR TITLE
Specify mysql-selinux explicitly because conditionals are not handled correctly

### DIFF
--- a/configs/sst_cs_apps-db-mariadb.yaml
+++ b/configs/sst_cs_apps-db-mariadb.yaml
@@ -20,6 +20,7 @@ data:
   - mariadb-test
   - mariadb-connector-c-devel
   - mariadb-connector-c-test
+  - mysql-selinux # because package mariadb-server requires (mysql-selinux if selinux-policy-targeted)
 
   labels:
   - eln


### PR DESCRIPTION
package mariadb-server requires (mysql-selinux if selinux-policy-targeted)
