### PR TITLE
Add mysql-selinux specifically to mysql-server workload as well

### DIFF
--- a/configs/sst_cs_apps-db-mysql.yaml
+++ b/configs/sst_cs_apps-db-mysql.yaml
@@ -12,6 +12,7 @@ data:
   - mysql-devel
   - mysql-server
   - mysql-test
+  - mysql-selinux
 
   labels:
   - eln


### PR DESCRIPTION
It was mentioned a correct thing is to put it to both, mariadb and also mysql workloads.