### PR TITLE
i18n input-methods: change Japanese IME from ibus-kkc to ibus-anthy

### DIFF
--- a/configs/sst_i18n-input-methods.yaml
+++ b/configs/sst_i18n-input-methods.yaml
@@ -13,8 +13,8 @@ data:
   - gtk2-immodule-xim
   - gtk3-immodule-xim
   - ibus
+  - ibus-anthy
   - ibus-hangul
-  - ibus-kkc
   - ibus-libpinyin
   - ibus-libzhuyin
   - ibus-m17n


### PR DESCRIPTION
https://fedoraproject.org/wiki/Changes/ibus-anthy_for_default_Japanese_IME