### PR TITLE
sst_platform_tools-unwanted.yaml: Do not mark nscd as unwanted

### DIFF
--- a/configs/sst_platform_tools-unwanted-future.yaml
+++ b/configs/sst_platform_tools-unwanted-future.yaml
@@ -1,0 +1,12 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Platform Tools Unwanted Packages (ELN)
+  description: Platform Tools recommendations for packages not to ship (future)
+  maintainer: sst_platform_tools
+  labels:
+  - eln
+
+  unwanted_packages:
+  # Remove nscd in favour of sssd.
+  - nscd

--- a/configs/sst_platform_tools-unwanted.yaml
+++ b/configs/sst_platform_tools-unwanted.yaml
@@ -35,8 +35,6 @@ data:
   - libmcpp-devel
   # Remove the temporary compat package for libpthread_nonshared.a.
   - compat-libpthread-nonshared
-  # Remove nscd in favour of sssd.
-  - nscd
   # Remove jsoncpp and rhash which are not used by cmake.
   - jsoncpp
   - rhash


### PR DESCRIPTION
nscd should be removed from future ELN, but not the c9s iteration.

@codonell Internal records need updating as well.