### PR TITLE
Update sst_security_crypto-unwanted.yaml

### DIFF
--- a/configs/sst_security_crypto-unwanted.yaml
+++ b/configs/sst_security_crypto-unwanted.yaml
@@ -19,6 +19,7 @@ data:
   - python2-pycryptodomex
   - python3-ecdsa
   - python3-pycryptodomex
+  - python3-pyOpenSSL
   
   labels:
   - eln


### PR DESCRIPTION
We also want to avoid PyOpenSSL, not because it is a bad package but because upstream want to drop it and provided good alternatives.