### PR TITLE
sst_platform_tools-unwanted.yaml: Mark libbsd as unwanted

### DIFF
--- a/configs/sst_platform_tools-unwanted.yaml
+++ b/configs/sst_platform_tools-unwanted.yaml
@@ -38,3 +38,7 @@ data:
   # Remove jsoncpp and rhash which are not used by cmake.
   - jsoncpp
   - rhash
+  # libbsd contains functionality which is not thread-safe/incompatible
+  # with glibc (fgetln, setproctitle).  fgetln should calls be replaced
+  # with getline, arc4random* with a PRNG from a cryptograhpic library.
+  - libbsd


### PR DESCRIPTION
This continues a tradition I started with Red Hat Enterprise Linux 7. The concerns are pretty much unchanged (the `fgetln` implementation changed radically, but still has problems).

@codonell @JeffreyALaw As discussed internally.