### PR TITLE
Only list the gnome-shell-extensions package for GNOME Shell extensions

### DIFF
--- a/configs/sst_desktop-gnome-desktop.yaml
+++ b/configs/sst_desktop-gnome-desktop.yaml
@@ -25,13 +25,7 @@ data:
   - gnome-remote-desktop
   - gnome-session
   - gnome-shell
-  - gnome-shell-extension-auto-move-windows
-  - gnome-shell-extension-dash-to-dock
-  - gnome-shell-extension-drive-menu
-  - gnome-shell-extension-native-window-placement
-  - gnome-shell-extension-screenshot-window-sizer
-  - gnome-shell-extension-windowsNavigator
-  - gnome-shell-extension-workspace-indicator
+  - gnome-shell-extensions
   - gnome-tweaks
   - chrome-gnome-shell
   - low-memory-monitor
@@ -81,15 +75,5 @@ data:
     redhat-backgrounds:
       srpm: redhat-logos
       description: Red Hat-related desktop backgrounds
-      requires: []
-      buildrequires: []
-    gnome-shell-extension-systemMonitor:
-      srpm: gnome-shell-extensions
-      description: This GNOME Shell extension is a message tray indicator for CPU and memory usage
-      requires: []
-      buildrequires: []
-    gnome-shell-extension-user-theme:
-      srpm: gnome-shell-extensions
-      description: Support for custom themes in GNOME Shell
       requires: []
       buildrequires: []


### PR DESCRIPTION
On RHEL all the supported GNOME Shell extensions are bundled and shipped in the
gnome-shell-extensions package.