### PR TITLE
Exclude qemu

### DIFF
--- a/configs/sst_virtualization-exclusion.yaml
+++ b/configs/sst_virtualization-exclusion.yaml
@@ -15,6 +15,7 @@ data:
   - netcf
   - ocaml-camlp4
   - OVMF
+  - qemu
   - perl-Sys-Virt
   - rhevm-guest-agent
   - spice-html5


### PR DESCRIPTION
In RHEL, we use qemu-kvm that is different than qemu in fedora.
qemu-kvm is successfully added but qemu is still listed as included
in content resolver.

Explicitly exclude qemu to not include it RHEL.