### PR TITLE
Update Ruby related config files.

### DIFF
--- a/configs/sst_cs_apps-ruby-db-connectors.yaml
+++ b/configs/sst_cs_apps-ruby-db-connectors.yaml
@@ -6,8 +6,6 @@ data:
   maintainer: sst_cs_apps
 
   packages:
-  - rubygem-bson
-  - rubygem-mongo
   - rubygem-mysql2
   - rubygem-pg
 

--- a/configs/sst_cs_apps-ruby.yaml
+++ b/configs/sst_cs_apps-ruby.yaml
@@ -7,6 +7,26 @@ data:
 
   packages:
   - ruby
+  - ruby-default-gems
+  - ruby-devel
+  - ruby-libs
+  - rubygem-bigdecimal
+  - rubygem-bundler
+  - rubygem-io-console
+  - rubygem-irb
+  - rubygem-json
+  - rubygem-minitest
+  - rubygem-power_assert
+  - rubygem-psych
+  - rubygem-rake
+  - rubygem-rbs
+  - rubygem-rdoc
+  - rubygem-rexml
+  - rubygem-rss
+  - rubygem-test-unit
+  - rubygem-typeprof
+  - rubygems
+  - rubygems-devel
   - rubygem-abrt
 
   labels:


### PR DESCRIPTION
* Add binary RPMs from ruby SRPM except ruby-doc.
* Remove rubygem-bson, rubygem-mongo as we do not ship it.

As seeing the nodejs config file, nodejs-docs was not added to the `<packages>`, I did not add ruby-doc to the `<packages>` too.
https://github.com/minimization/content-resolver-input/blob/master/configs/sst_cs_apps-nodejs.yaml

@voxik review please.
