### PR TITLE
sst_networking: mark dropwatch as unwanted

### DIFF
--- a/configs/sst_networking-tools.yaml
+++ b/configs/sst_networking-tools.yaml
@@ -27,6 +27,9 @@ data:
   - wireshark
   - wireshark-cli
 
+  unwanted_packages:
+  - dropwatch
+
   labels:
   - eln
   - c9s


### PR DESCRIPTION
It is already not included, but lets have it flagged otherwise.