### PR TITLE
Add iptables-nft

### DIFF
--- a/configs/sst_openstack.yaml
+++ b/configs/sst_openstack.yaml
@@ -86,6 +86,7 @@ data:
   - ipset
   - iptables
   - iptables-libs
+  - iptables-nft
   - iptables-services
   - iputils
   - ipxe-bootimgs


### PR DESCRIPTION
OpenStack requires ebtables which is included in iptables-nft in
Fecora/ELN.