### PR TITLE
Fix the gnome-desktop workload

### DIFF
--- a/configs/sst_desktop-gnome-desktop.yaml
+++ b/configs/sst_desktop-gnome-desktop.yaml
@@ -25,7 +25,13 @@ data:
   - gnome-remote-desktop
   - gnome-session
   - gnome-shell
-  - gnome-shell-extensions
+  - gnome-shell-extension-auto-move-windows
+  - gnome-shell-extension-dash-to-dock
+  - gnome-shell-extension-drive-menu
+  - gnome-shell-extension-native-window-placement
+  - gnome-shell-extension-screenshot-window-sizer
+  - gnome-shell-extension-windowsNavigator
+  - gnome-shell-extension-workspace-indicator
   - gnome-tweaks
   - chrome-gnome-shell
   - low-memory-monitor
@@ -75,5 +81,15 @@ data:
     redhat-backgrounds:
       srpm: redhat-logos
       description: Red Hat-related desktop backgrounds
+      requires: []
+      buildrequires: []
+    gnome-shell-extension-systemMonitor:
+      srpm: gnome-shell-extensions
+      description: This GNOME Shell extension is a message tray indicator for CPU and memory usage
+      requires: []
+      buildrequires: []
+    gnome-shell-extension-user-theme:
+      srpm: gnome-shell-extensions
+      description: Support for custom themes in GNOME Shell
       requires: []
       buildrequires: []


### PR DESCRIPTION
Revert the previous change as the gnome-shell-extensions is an SRPM and not RPM