### PR TITLE
Drop libaec from sst_desktop unwanted

### DIFF
--- a/configs/sst_desktop-unwanted.yaml
+++ b/configs/sst_desktop-unwanted.yaml
@@ -56,7 +56,6 @@ data:
   - libchamplain
   - libbluray
   - libdmapsharing
-  - libaec
   # Replaced by tracker3
   - tracker
   - tracker-miners


### PR DESCRIPTION
It was moved to another subsystem