### PR TITLE
Drop gnome-getting-started-docs

### DIFF
--- a/configs/sst_ccs-desktop-documentation.yaml
+++ b/configs/sst_ccs-desktop-documentation.yaml
@@ -7,7 +7,6 @@ data:
 
   packages:
   - gnome-user-docs
-  - gnome-getting-started-docs
 
   labels:
   - eln


### PR DESCRIPTION
It was retired in upstream in GNOME 40