### PR TITLE
change rt-tests to realtime-tests and rt-setup to realtime-setup

### DIFF
--- a/configs/sst_kernel_rats-perf.yaml
+++ b/configs/sst_kernel_rats-perf.yaml
@@ -14,8 +14,8 @@ data:
       - stress-ng
 
   package_placeholders:
-    rt-tests:
-      srpm: rt-tests
+    realtime-tests:
+      srpm: realtime-tests
       description: This package is not in Fedora (yet), but we want it here.
       requires:
         - bash

--- a/configs/sst_kernel_rats-setup.yaml
+++ b/configs/sst_kernel_rats-setup.yaml
@@ -1,7 +1,7 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: rt-setup
+  name: realtime-setup
   description: Package that creates realtime group and limits
   maintainer: sst_kernel_rats
   packages: []
@@ -10,8 +10,8 @@ data:
   - c9s
 
   package_placeholders:
-    rt-setup:
-      srpm: rt-setup
+    realtime-setup:
+      srpm: realtime-setup
       description: This package is not in Fedora (yet), but we want it here.
       requires:
       - pam


### PR DESCRIPTION
rt-tests is now in Fedora and is called realtime-tests
rt-setup is now in Fedora and is called realtime-setup

Change the yaml files to reflect this