### PR TITLE
Include mozjs78 in the GNOME Desktop workload

### DIFF
--- a/configs/sst_desktop-gnome-desktop.yaml
+++ b/configs/sst_desktop-gnome-desktop.yaml
@@ -35,6 +35,7 @@ data:
   - gnome-tweaks
   - chrome-gnome-shell
   - low-memory-monitor
+  - mozjs78
   - power-profiles-daemon
   - tracker3
   - uresourced


### PR DESCRIPTION
Be explicit about the version that we depend on.