### PR TITLE
Drop gnome-shell-extension-horizontal-workspaces from GNOME Classic workload

### DIFF
--- a/configs/sst_desktop-gnome-classic-session.yaml
+++ b/configs/sst_desktop-gnome-classic-session.yaml
@@ -9,7 +9,6 @@ data:
   - gnome-classic-session
   - gnome-menus
   - gnome-shell-extension-apps-menu
-  - gnome-shell-extension-horizontal-workspaces
   - gnome-shell-extension-places-menu
   - gnome-shell-extension-launch-new-instance
   - gnome-shell-extension-window-list

--- a/configs/sst_desktop-unwanted.yaml
+++ b/configs/sst_desktop-unwanted.yaml
@@ -56,6 +56,7 @@ data:
   - libchamplain
   - libbluray
   - libdmapsharing
+  - gnome-shell-extension-horizontal-workspaces
   # Replaced by tracker3
   - tracker
   - tracker-miners


### PR DESCRIPTION
GNOME 40 uses horizontal workspaces by default, so this is not needed anymore.