### PR TITLE
sst_kernel_debug: add crash-trace-command and crash-gcore-command

### DIFF
--- a/configs/sst_kernel_debug-kdump.yaml
+++ b/configs/sst_kernel_debug-kdump.yaml
@@ -5,12 +5,25 @@ data:
   name: Kdump support
   description: Tools necessary to support vmcore dumping and analyzing
   maintainer: sst_kernel_debug
+
   packages:
   - kexec-tools
   - kdump-anaconda-addon
   - memstrack
   - crash
   - snappy
+  - crash-trace-command
+    # Read ftrace data from a core dump file.
+
+  arch_packages:
+    aarch64:
+      - crash-gcore-command
+        # Adds a "gcore" command which can create a core dump file of a user-space task that was running in a kernel dumpfile.
+    ppc64le:
+      - crash-gcore-command
+    x86_64:
+      - crash-gcore-command
+
   labels:
   - eln
   - c9s


### PR DESCRIPTION
Both two packages are supported in rhel7 and rhel9, but not added into
Fedora in the past. Recently their ahthor and maintainer has added them
into Fedora, so add them into rhel9 content-set.

https://src.fedoraproject.org/rpms/crash-trace-command
https://src.fedoraproject.org/rpms/crash-gcore-command

The supportd ARCHes are:
crash-trace-command:
 - aarch64
 - ppc64le
 - s390x
 - x86_64
crash-gcore-command:
 - aarch64
 - ppc64le
 - x86_64