### PR TITLE
Add new workload for packages needed to build Python RPM packages

### DIFF
--- a/configs/sst_cs_apps-python-devel.yaml
+++ b/configs/sst_cs_apps-python-devel.yaml
@@ -1,0 +1,17 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Python development packages
+  description: Packages needed to build Python RPM packages
+  maintainer: sst_cs_apps
+
+  packages:
+  - python3-devel
+  - python3-rpm-generators
+  - python3-rpm-macros
+  - python-srpm-macros
+  - python-rpm-macros
+
+  labels:
+  - eln
+  - c9s


### PR DESCRIPTION
We support building Python RPM packages so these tools should be included in AppStream.

CC @encukou @hroncok 