### PR TITLE
sst_kernel_debug: mark crash-ptdump-command as unwanted

### DIFF
--- a/configs/sst_kernel_debug-unwanted.yaml
+++ b/configs/sst_kernel_debug-unwanted.yaml
@@ -7,6 +7,7 @@ data:
 
   unwanted_packages:
   - netdump-server
+  - crash-ptdump-command
 
   labels:
   - eln


### PR DESCRIPTION
Package crash-ptdump-command is not supported any more, so discard it from
Fedora and RHEL9.