### PR TITLE
make 'qperf' as unwanted package

### DIFF
--- a/configs/sst_nic_rdma-unwanted.yaml
+++ b/configs/sst_nic_rdma-unwanted.yaml
@@ -38,6 +38,7 @@ data:
   - ibutils-devel
   - ibutils-libs
   - ibutils-static
+  - qperf
   labels:
   - eln
   - c9s


### PR DESCRIPTION
qperf is almost dead in upstream.

Signed-off-by: Honggang Li <honli@redhat.com>