### PR TITLE
Mark file-roller as unwanted

### DIFF
--- a/configs/sst_desktop_applications-nautilus.yaml
+++ b/configs/sst_desktop_applications-nautilus.yaml
@@ -6,7 +6,6 @@ data:
   maintainer: sst_desktop
 
   packages:
-  - file-roller
   - gvfs
   - gvfs-client
   - gvfs-fuse

--- a/configs/sst_desktop_applications-unwanted.yaml
+++ b/configs/sst_desktop_applications-unwanted.yaml
@@ -36,6 +36,8 @@ data:
   - gnome-boxes
   # Wasn't part of RHEL 8 and won't be part of RHEL 9
   - ImageMagick
+  # Functionality moved into Nautilus, see https://pagure.io/fedora-workstation/issue/167
+  - file-roller
   labels:
   - eln
   - c9s


### PR DESCRIPTION
file-roller isn't needed anymore as the functionality was (mostly) moved
to Nautilus.