### PR TITLE
python-crypto is bad crypto

### DIFF
--- a/configs/sst_security_crypto-unwanted.yaml
+++ b/configs/sst_security_crypto-unwanted.yaml
@@ -20,6 +20,8 @@ data:
   - python3-ecdsa
   - python3-pycryptodomex
   - python3-pyOpenSSL
+  - python3-crypto
+  - python2-crypto
   
   labels:
   - eln


### PR DESCRIPTION
cc @simo5, please ack

(This package just got assigned to Python Maint under a incorrect reason, so before I move it back to @lnykryn / @kdudka, I also went ahead and explicitly marked is as unwanted.)