### PR TITLE
lorax-template: Remove xorg-x11-server-utils

### DIFF
--- a/configs/sst_program-lorax-template.yaml
+++ b/configs/sst_program-lorax-template.yaml
@@ -36,7 +36,6 @@ data:
   - bzip2
   - systemd
   - rsyslog
-  - xorg-x11-server-utils
   - xorg-x11-xauth
   - dbus-x11
   - metacity


### PR DESCRIPTION
This package is retired in F34, and would have been brought in by dependencies anyway, so stop listing it explicitly.