### PR TITLE
Remove python-podman-api

### DIFF
--- a/configs/sst_conatiner_tools.yaml
+++ b/configs/sst_conatiner_tools.yaml
@@ -18,7 +18,6 @@ data:
    - libslirp
    - oci-seccomp-bpf-hook
    - podman
-   - python-podman-api
    - runc
    - skopeo
    - slirp4netns


### PR DESCRIPTION
The python-podman-api package is no longer required in RHEL9 as it's not part of the container-tools module.