### PR TITLE
firewall: unwanted: add iptables-legacy{,-libs}

### DIFF
--- a/configs/sst_networking-firewall-unwanted.yaml
+++ b/configs/sst_networking-firewall-unwanted.yaml
@@ -13,3 +13,5 @@ data:
   - iptstate
   - bridge-utils
   - ebtables-legacy
+  - iptables-legacy
+  - iptables-legacy-libs


### PR DESCRIPTION
We want the iptables-nft variants in RHEL-9.