### PR TITLE
Add `srpm` entry to hesiod

### DIFF
--- a/configs/sst_identity_management-hesiod.yaml
+++ b/configs/sst_identity_management-hesiod.yaml
@@ -20,3 +20,4 @@ data:
                 - automake
                 - libtool
                 - libidn-devel
+            srpm: hesiod


### PR DESCRIPTION
This field was made mandatory in
aad1697129d260f852259610d891539766abdd95 but not added to existing
packages, resulting in hesiod not showing up.