### PR TITLE
Update sst_high_availability-userspace-unwanted.yaml

### DIFF
--- a/configs/sst_high_availability-userspace-unwanted.yaml
+++ b/configs/sst_high_availability-userspace-unwanted.yaml
@@ -14,6 +14,60 @@ data:
   - clufter-lib-pcs
   - jing-trang
   - python3-clufter
+  - python-sphinxcontrib-apidoc
+  - python-sphinxcontrib-apidoc
+  - python-pyperclip
+  - python-testrepository
+  - python-hacking
+  - python-ddt
+  - python-certifi
+  - python-kerberos
+  - python-simplejson
+  - python-mimeparse
+  - zeromq
+  - python-extras
+  - python-monotonic
+  - python-voluptuous
+  - python-dulwich
+  - python-colorama
+  - python-oslo-sphinx
+  - python-testscenarios
+  - python-sphinx-epytext
+  - python-cliff
+  - python-cmd2
+  - python-testtools
+  - python-openstackdocstheme
+  - python-oslotest
+  - python-requests-mock
+  - python-sqlalchemy
+  - python-zmq
+  - python-stestr
+  - python-mox3
+  - python-oslo-config
+  - python-rfc3986
+  - python-fixtures
+  - openpgm
+  - python-d2to1
+  - future
+  - python-requests-kerberos
+  - python-msgpack
+  - python-wrapt
+  - python-os-service-types
+  - esmtp
+  - python-novaclient
+  - libesmtp
+  - python-pbr
+  - python-debtcollector
+  - python-oslo-serialization
+  - python-keystoneauth1
+  - python-stevedore
+  - python-oslo-i18n
+  - python-oslo-utils
+  - python-funcsigs
+  - python-iso8601
+  - python-jwt
+  - python-pexpect
+  - python-ptyprocess
 
   labels:
   - eln


### PR DESCRIPTION
These are all packages that we should no longer be depending on and can be removed from RHEL 9 (unless someone else needs them).