### PR TITLE
Add rsyslog-udpspoof to rsyslog workload

### DIFF
--- a/configs/sst_security_special_projects-rsyslog.yaml
+++ b/configs/sst_security_special_projects-rsyslog.yaml
@@ -23,6 +23,7 @@ data:
   - rsyslog-pgsql
   - rsyslog-relp
   - rsyslog-snmp
+  - rsyslog-udpspoof
   - librdkafka-devel
   - liblognorm-doc
 


### PR DESCRIPTION
Requested to RHEL-8, so let's have it in RHEL-9 as well: https://bugzilla.redhat.com/show_bug.cgi?id=1869874