### PR TITLE
connections was renamed to gnome-connections

### DIFF
--- a/configs/sst_desktop_applications-connections.yaml
+++ b/configs/sst_desktop_applications-connections.yaml
@@ -6,7 +6,7 @@ data:
   maintainer: sst_desktop_applications
 
   packages:
-  - connections
+  - gnome-connections
 
   labels:
   - eln


### PR DESCRIPTION
See https://bodhi.fedoraproject.org/updates/FEDORA-2021-590a47f6b1