### PR TITLE
sst_kernel_tps-tracing: add opencsd library

### DIFF
--- a/configs/sst_kernel_tps-tracing.yaml
+++ b/configs/sst_kernel_tps-tracing.yaml
@@ -15,6 +15,8 @@ data:
   arch_packages:
     aarch64:
       - bpftrace
+      - opencsd
+      - opencsd-devel
     ppc64le:
       - bpftrace
     s390x:


### PR DESCRIPTION
OpenCSD is a library for parsing ARM CoreSight traces in perf.