### PR TITLE
redfish-finder: add x86_64 and aarch64 arch exclusivity

### DIFF
--- a/configs/sst_kernel_ft-redfish-finder.yaml
+++ b/configs/sst_kernel_ft-redfish-finder.yaml
@@ -10,3 +10,9 @@ data:
 
   labels:
   - c9s
+
+  arch_packages:
+    x86_64:
+    - redfish-finder
+    aarch64:
+    - redfish-finder

--- a/configs/sst_kernel_ft-redfish-finder.yaml
+++ b/configs/sst_kernel_ft-redfish-finder.yaml
@@ -5,8 +5,7 @@ data:
   description: Utility for parsing SMBIOS information and configuring canonical BMC access
   maintainer: jsavitz
 
-  packages:
-  - redfish-finder
+  packages: []
 
   labels:
   - c9s


### PR DESCRIPTION
redfish-finder parses the output of dmidecode and this is only a relevant workflow on x86_64 and aarch64.

Signed-off-by: Joel Savitz <jsavitz@redhat.com>