### PR TITLE
SST_PLATFORM_STORAGE: Fixed SRPM definition for vdo placeholder.

### DIFF
--- a/configs/sst_platform_storage-packages.yaml
+++ b/configs/sst_platform_storage-packages.yaml
@@ -141,7 +141,7 @@ data:
       srpm: pmreorder
     vdo:
       description: This package is currently only available in RHEL.  (Fedora package is available via COPR)
-      srpm: kmod-kvdo
+      srpm: vdo
     stratisd:
       description: RHEL builds are bundled and use rust-toolset.  Placeholder so we do not pull in Fedoras dependencies.
       srpm: stratisd


### PR DESCRIPTION
The specification of kmod-kvdo for the SRPM to the 'vdo' package was by
mistake.  This change fixes that typo.