### PR TITLE
Rename freeipa to ipa

### DIFF
--- a/configs/sst_identity_management-ansible-freeipa.yaml
+++ b/configs/sst_identity_management-ansible-freeipa.yaml
@@ -7,7 +7,7 @@ data:
 
   packages:
   - ansible-freeipa
-  - freeipa-selinux # rich dependency that is otherwise unmet
+  - ipa-selinux # rich dependency that is otherwise unmet
 
   labels:
   - eln

--- a/configs/sst_identity_management-freeipa-client-samba.yaml
+++ b/configs/sst_identity_management-freeipa-client-samba.yaml
@@ -6,9 +6,9 @@ data:
   maintainer: sst_identity_management
 
   packages:
-  - freeipa-client
-  - freeipa-client-samba
-  - freeipa-selinux # rich dependency that is otherwise unmet
+  - ipa-client
+  - ipa-client-samba
+  - ipa-selinux # rich dependency that is otherwise unmet
 
   labels:
   - eln

--- a/configs/sst_identity_management-freeipa-client.yaml
+++ b/configs/sst_identity_management-freeipa-client.yaml
@@ -6,8 +6,8 @@ data:
   maintainer: sst_identity_management
 
   packages:
-  - freeipa-client
-  - freeipa-selinux # rich dependency that is otherwise unmet
+  - ipa-client
+  - ipa-selinux # rich dependency that is otherwise unmet
 
   labels:
   - eln

--- a/configs/sst_identity_management-freeipa-server-dc.yaml
+++ b/configs/sst_identity_management-freeipa-server-dc.yaml
@@ -6,10 +6,10 @@ data:
   maintainer: sst_identity_management
 
   packages:
-  - freeipa-server
-  - freeipa-server-trust-ad
-  - freeipa-healthcheck
-  - freeipa-selinux # rich dependency that is otherwise unmet
+  - ipa-server
+  - ipa-server-trust-ad
+  - ipa-healthcheck
+  - ipa-selinux # rich dependency that is otherwise unmet
 
   labels:
   - eln

--- a/configs/sst_identity_management-freeipa-server-full.yaml
+++ b/configs/sst_identity_management-freeipa-server-full.yaml
@@ -6,11 +6,11 @@ data:
   maintainer: sst_identity_management
 
   packages:
-  - freeipa-server
-  - freeipa-server-trust-ad
-  - freeipa-server-dns
-  - freeipa-healthcheck
-  - freeipa-selinux # rich dependency that is otherwise unmet
+  - ipa-server
+  - ipa-server-trust-ad
+  - ipa-server-dns
+  - ipa-healthcheck
+  - ipa-selinux # rich dependency that is otherwise unmet
 
   labels:
   - eln

--- a/configs/sst_identity_management-freeipa-server.yaml
+++ b/configs/sst_identity_management-freeipa-server.yaml
@@ -6,8 +6,8 @@ data:
   maintainer: sst_identity_management
 
   packages:
-  - freeipa-server
-  - freeipa-selinux # rich dependency that is otherwise unmet
+  - ipa-server
+  - ipa-selinux # rich dependency that is otherwise unmet
 
   labels:
   - eln

--- a/configs/sst_identity_management-idm-client-tools.yaml
+++ b/configs/sst_identity_management-idm-client-tools.yaml
@@ -6,8 +6,8 @@ data:
   maintainer: sst_identity_management
 
   packages:
-  - freeipa-healthcheck
-  - freeipa-client-epn
+  - ipa-healthcheck
+  - ipa-client-epn
   - sssd-tools
   - realmd
   - adcli
@@ -17,7 +17,7 @@ data:
   - cockpit-session-recording
   - gssproxy
   - certmonger
-  - freeipa-selinux # rich dependency that is otherwise unmet
+  - ipa-selinux # rich dependency that is otherwise unmet
 
   labels:
   - eln


### PR DESCRIPTION
distrobaker now renames "freeipa" and "freeipa-healthcheck" in both ELN and C9S. Use the new names directly.

This is a follow up to my discussion with @asamalik .