### PR TITLE
remove qperf from rdma appstream

### DIFF
--- a/configs/sst_nic_rdma-appstream.yaml
+++ b/configs/sst_nic_rdma-appstream.yaml
@@ -25,13 +25,9 @@ data:
     # not armv7hl
     aarch64:
       - opensm-devel
-      - qperf
     ppc64le:
       - opensm-devel
-      - qperf
     s390x:
       - opensm-devel
-      - qperf
     x86_64:
       - opensm-devel
-      - qperf


### PR DESCRIPTION
qperf is dead in upstream. It had been included in rdma-unwanted and
rdma-appstream. Let's fix this mistake.

Signed-off-by: Honggang Li <honli@redhat.com>