### PR TITLE
Move lcms2 to the gnome-desktop workload

### DIFF
--- a/configs/sst_cs_system_management-sys-management.yaml
+++ b/configs/sst_cs_system_management-sys-management.yaml
@@ -27,7 +27,6 @@ data:
   - ipmitool
   - iprutils
   - jasper-devel
-  - lcms2-devel
   - libgphoto2-devel
   - librabbitmq
   - librabbitmq-devel

--- a/configs/sst_desktop-gnome-desktop.yaml
+++ b/configs/sst_desktop-gnome-desktop.yaml
@@ -34,6 +34,7 @@ data:
   - gnome-tweaks
   - chrome-gnome-shell
   - low-memory-monitor
+  - lcms2
   - mozjs78
   - power-profiles-daemon
   - tracker


### PR DESCRIPTION
Required by color management