### PR TITLE
Make clutter* and cogl package wanted again on RHEL 9

### DIFF
--- a/configs/sst_desktop-cheese.yaml
+++ b/configs/sst_desktop-cheese.yaml
@@ -6,6 +6,10 @@ data:
   maintainer: sst_desktop
 
   packages:
+  - clutter
+  - clutter-gtk
+  - clutter-gst3
+  - cogl
   - cheese
 
   labels:

--- a/configs/sst_desktop-totem.yaml
+++ b/configs/sst_desktop-totem.yaml
@@ -6,6 +6,10 @@ data:
   maintainer: sst_desktop
 
   packages:
+  - clutter
+  - clutter-gtk
+  - clutter-gst3
+  - cogl
   - totem
   - totem-video-thumbnailer
 

--- a/configs/sst_desktop-unwanted_eln.yaml
+++ b/configs/sst_desktop-unwanted_eln.yaml
@@ -44,6 +44,10 @@ data:
   - mozjs60
   - mozjs68
   # Old or deprecated or unwanted or unused stuff
+  - clutter-gtk
+  - clutter-gst3
+  - clutter
+  - cogl
   - libIDL
   - redhat-menus
   - dbus-c++
@@ -59,4 +63,4 @@ data:
   # libhandy1 renamed to libhandy in F34+
   - libhandy1
   labels:
-  - c9s
+  - eln


### PR DESCRIPTION
We won't have time to move Cheese and Totem away from using them, so we
are targeting RHEL 10 there, hence create a new unwanted_eln file and
move the definitions there.