### PR TITLE
cppunit is owned by sst_desktop

### DIFF
--- a/configs/sst_platform_tools-unwanted.yaml
+++ b/configs/sst_platform_tools-unwanted.yaml
@@ -14,9 +14,10 @@ data:
   - cppcheck
   - cppcheck-gui
   - cppcheck-htmlreport
-  - cppunit
-  - cppunit-devel
-  - cppunit-doc
+  # Owned by sst_desktop
+  # - cppunit
+  # - cppunit-devel
+  # - cppunit-doc
   - tinyxml2
   - tinyxml2-devel
   - dpkg


### PR DESCRIPTION
Comment it out in sst_platform_tools unwanted file, but leave is there
for clarity (as requested by Tilmann Scheller)