### PR TITLE
sst_kernel_tps: move perf into its own workload

### DIFF
--- a/configs/sst_kernel_tps-perf.yaml
+++ b/configs/sst_kernel_tps-perf.yaml
@@ -1,0 +1,13 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Perf
+  description: Performance analysis tools for Linux
+  maintainer: sst_kernel_tps
+
+  packages:
+  - perf
+
+  labels:
+  - eln
+  - c9s

--- a/configs/sst_kernel_tps-tracing.yaml
+++ b/configs/sst_kernel_tps-tracing.yaml
@@ -7,7 +7,6 @@ data:
 
   packages:
   - bcc
-  - perf
   - strace
   - trace-cmd
   - libtracefs


### PR DESCRIPTION
The perf package currently conflicts with libtraveevent.