### PR TITLE
Add libinput-utils to the Wayland workload

### DIFF
--- a/configs/sst_graphics_infrastructure-Wayland-Infrastructure.yaml
+++ b/configs/sst_graphics_infrastructure-Wayland-Infrastructure.yaml
@@ -10,6 +10,7 @@ data:
     - waypipe
     # Needed by the NVIDIA drivers to use Mutter's EGLStreams
     - egl-wayland
+    - libinput-utils
 
   labels:
     - eln


### PR DESCRIPTION
Theres are debugging tools that may need to be run on a customer machine and,
more importantly, they have additional Requires that we need to pull in.


cc @csoriano1618 