### PR TITLE
Add unwanted firmware packages to the kernel unwanted list

### DIFF
--- a/configs/sst_kernel_maintainers-kernel-unwanted.yaml
+++ b/configs/sst_kernel_maintainers-kernel-unwanted.yaml
@@ -6,10 +6,16 @@ data:
   maintainer: sst_kernel_maintainers
 
   unwanted_packages:
+  - iwl3945-firmware
+  - iwl4965-firmware
+  - iwl6000-firmware
   - kernel-ipaclones-internal
   - kernel-modules-internal
   - kernel-selftests-internal
   - kernel-zfcpdump-modules-internal
+  - libertas-sd8686-firmware
+  - libertas-usb8388-firmware
+  - libertas-usb8388-olpc-firmware
 
   labels:
   - eln


### PR DESCRIPTION
Some firmware packages are not needed anymore, as the firmware they
provide are not used by latest kernels in RHEL (eg. due module not
being built or disabled). Thus add them to the unwanted.

See https://issues.redhat.com/browse/RHELPLAN-46582 for more details.

Signed-off-by: Herton R. Krzesinski <herton@redhat.com>