### PR TITLE
Add missing binary packages created by linux-firmware component

### DIFF
--- a/configs/sst_kernel_maintainers-kernel-base.yaml
+++ b/configs/sst_kernel_maintainers-kernel-base.yaml
@@ -6,6 +6,19 @@ data:
     maintainer: sst_kernel_maintainers
     packages:
         - bpftool
+        - iwl1000-firmware
+        - iwl100-firmware
+        - iwl105-firmware
+        - iwl135-firmware
+        - iwl2000-firmware
+        - iwl2030-firmware
+        - iwl3160-firmware
+        - iwl5000-firmware
+        - iwl5150-firmware
+        - iwl6000g2a-firmware
+        - iwl6000g2b-firmware
+        - iwl6050-firmware
+        - iwl7260-firmware
         - kernel-abi-whitelists
         - kernel-core
         - kernel-cross-headers
@@ -15,6 +28,9 @@ data:
         - kernel-modules-extra
         - kernel-tools
         - linux-firmware
+        - linux-firmware-whence
+        - liquidio-firmware
+        - netronome-firmware
         - perf
         - python3-perf
     labels:


### PR DESCRIPTION
We were listing only linux-firmware, but there are other packages
created by linux-firmware src.rpm that we were not listing, and
that are installed by default or there is at the moment a kernel module
which is built and requires the firmware provided by them.

There is one exception here though, I'm not adding libertas-sd8787-firmware,
because it seems we probably should not be building on centos/rhel the kernel
modules that require it anymore (mwifiex_sdio, btmrvl_sdio), so leaving this
out for now. And on errata this specific firmware package also falls
into the "not in Product Listings" category already.

See also https://issues.redhat.com/browse/RHELPLAN-46582

Signed-off-by: Herton R. Krzesinski <herton@redhat.com>