### PR TITLE
configs: add coreos-installer to sst_edge

### DIFF
--- a/configs/sst_edge.yaml
+++ b/configs/sst_edge.yaml
@@ -12,6 +12,7 @@ data:
   - ignition
   - ostree
   - rpm-ostree
+  - coreos-installer
 
   arch_packages:
     x86_64:


### PR DESCRIPTION
We need the installer to be part of the system to be used in edge.

cc @nullr0ute

Signed-off-by: Antonio Murdaca <runcom@linux.com>