### PR TITLE
Add missing kernel "meta" package to the sst_kernel_maintainers-kernel-base

### DIFF
--- a/configs/sst_kernel_maintainers-kernel-base.yaml
+++ b/configs/sst_kernel_maintainers-kernel-base.yaml
@@ -19,6 +19,7 @@ data:
         - iwl6000g2b-firmware
         - iwl6050-firmware
         - iwl7260-firmware
+        - kernel
         - kernel-abi-whitelists
         - kernel-core
         - kernel-cross-headers


### PR DESCRIPTION
The kernel src.rpm creates a binary kernel "meta" package that has no
files, it just pulls/requires kernel-core and kernel-modules (this was
done after the kernel was split into -core/-modules/-modules-extra on
Fedora). Just noted that we are missing it on the kernel-base list, thus
add it.

Signed-off-by: Herton R. Krzesinski <herton@redhat.com>