### PR TITLE
Update configs/sst_kernel_ft-memkind.yaml

### DIFF
--- a/configs/sst_kernel_ft-memkind.yaml
+++ b/configs/sst_kernel_ft-memkind.yaml
@@ -19,6 +19,12 @@ data:
   #        - arch-specific-package1   #     goes here.
   #
   arch_packages:
+      aarch64:
+          - memkind
+          - memkind-devel
+      ppc64le:
+          - memkind
+          - memkind-devel
       x86_64:
           - memkind
           - memkind-devel


### PR DESCRIPTION
Include aarch64 and ppc64le architectures to the
compose lists

Signed-off-by: Rafael Aquini <aquini@redhat.com>