### PR TITLE
Virt SST: drop fuse-sshfs and SLOF

### DIFF
--- a/configs/sst_virtualization-all.yaml
+++ b/configs/sst_virtualization-all.yaml
@@ -8,7 +8,6 @@ data:
   packages:
   - augeas
   - dtc
-  - fuse-sshfs
   - gtk-vnc2
   - hexedit
   - hivex
@@ -50,7 +49,6 @@ data:
     ppc64le:
     - libpmem
     - powerpc-utils
-    - SLOF
     - xorg-x11-drv-qxl
     aarch64:
     - edk2-aarch64


### PR DESCRIPTION
Dropping the packages as they are no longer required in RHEL 9

Signed-off-by: Yash Mankad <ymankad@redhat.com>