### PR TITLE
Removing pymongo from openstack workload

### DIFF
--- a/configs/sst_openstack.yaml
+++ b/configs/sst_openstack.yaml
@@ -249,7 +249,6 @@ data:
   - python3-pyasn1
   - python3-pyasn1-modules
   - python3-pycurl
-  - python3-pymongo
   - python3-PyMySQL
   - python3-pyOpenSSL
   - python3-pyparsing


### PR DESCRIPTION
Based on the mail discussion (May 2021), pymongo will either not
be needed in OSP17 or will be shipped for OSP outside of RHEL.