### PR TITLE
Remove references to rubygem-tilt

### DIFF
--- a/configs/sst_cs_apps-ruby.yaml
+++ b/configs/sst_cs_apps-ruby.yaml
@@ -32,15 +32,3 @@ data:
   labels:
   - eln
   - c9s
-
-  package_placeholders:
-    rubygem-tilt:
-      srpm: rubygem-tilt
-      description: Generic interface to multiple Ruby template engines
-# asamalik: These must be package names. We need to get these fixed
-#      requires:
-#        - ruby(rubygems)
-#
-#      buildrequires:
-#        - rubygem(minitest)
-#        - /usr/bin/ronn


### PR DESCRIPTION
We don't explicitly need rubygem-tilt. This was just failed attempt to provide placeholder providing limited set of BRs, otherwise rubygem-tilt pulls in almost "everything".