### PR TITLE
sst_graphics_infrastructure-codecs: remove vorbis

### DIFF
--- a/configs/sst_graphics_infrastructure-codecs.yaml
+++ b/configs/sst_graphics_infrastructure-codecs.yaml
@@ -7,7 +7,6 @@ data:
 
   packages:
     - libtheora
-    - vorbis
     - sbc
     - lame
     - libmad


### PR DESCRIPTION
It was pulling `vorbis-tools` into the compose despite `vorbis-tools` is on the list of unwanted packages of `sst_cs_plumbers`.