### PR TITLE
edge: Require nss-altfiles

### DIFF
--- a/configs/sst_edge.yaml
+++ b/configs/sst_edge.yaml
@@ -12,6 +12,7 @@ data:
   - ignition
   - ostree
   - rpm-ostree
+  - nss-altfiles
   - coreos-installer
 
   arch_packages:


### PR DESCRIPTION
In practice, rpm-ostree requires this today.  It's not
expressed as a hard dependency because we may do something else
in the future.