### PR TITLE
firewall: Update list of wanted/unwanted packages

### DIFF
--- a/configs/sst_networking-firewall-tools.yaml
+++ b/configs/sst_networking-firewall-tools.yaml
@@ -10,17 +10,17 @@ data:
   - c9s
 
   packages:
-  - arptables
-  - arptables-services
   - conntrack-tools
-  - ebtables
-  - ebtables-services
   - firewall-applet
   - firewall-config
   - firewalld
   - ipset
+  - ipset-libs
   - ipset-service
-  - iptables
+  - iptables-libs
   - iptables-nft
+  - iptables-nft-services
   - iptables-services
+  - iptables-utils
   - nftables
+  - python3-nftables

--- a/configs/sst_networking-firewall-unwanted.yaml
+++ b/configs/sst_networking-firewall-unwanted.yaml
@@ -10,8 +10,10 @@ data:
   - c9s
 
   unwanted_packages:
+  - arptables-legacy
   - iptstate
   - bridge-utils
   - ebtables-legacy
   - iptables-legacy
+  - iptables-legacy-devel
   - iptables-legacy-libs


### PR DESCRIPTION
Like RHEL8, RHEL9 won't come with legacy variants of arptables, ebtables
or iptables. Since nft variants are provided by iptables-nft, adjust
package lists accordingly.

Drop plain 'iptables' package which no longer exists.

For the sake of completeness, add required -libs packages although they
should come automatically as dependencies.

Add iptables-utils package, it ships useful helper tools.