### PR TITLE
rhsm: drop subscription-manager-initial-setup-addon

### DIFF
--- a/configs/sst_subscription_manager-subscription-manager.yaml
+++ b/configs/sst_subscription_manager-subscription-manager.yaml
@@ -18,9 +18,7 @@ data:
     aarch64:
     - libdnf-plugin-subscription-manager
     - python3-subscription-manager-rhsm
-    - rhsm-gtk
     - subscription-manager
-    - subscription-manager-initial-setup-addon
     - subscription-manager-plugin-ostree
     - subscription-manager-rhsm-certificates
     # asamalik: leaving out debuginfo packages, they're special and not in the repos
@@ -32,9 +30,7 @@ data:
     i686:
     - libdnf-plugin-subscription-manager
     - python3-subscription-manager-rhsm
-    - rhsm-gtk
     - subscription-manager
-    - subscription-manager-initial-setup-addon
     - subscription-manager-plugin-ostree
     - subscription-manager-rhsm-certificates
     # asamalik: leaving out debuginfo packages, they're special and not in the repos
@@ -46,9 +42,7 @@ data:
     ppc64le:
     - libdnf-plugin-subscription-manager
     - python3-subscription-manager-rhsm
-    - rhsm-gtk
     - subscription-manager
-    - subscription-manager-initial-setup-addon
     - subscription-manager-plugin-ostree
     - subscription-manager-rhsm-certificates
     # asamalik: leaving out debuginfo packages, they're special and not in the repos
@@ -60,9 +54,7 @@ data:
     s390x:
     - libdnf-plugin-subscription-manager
     - python3-subscription-manager-rhsm
-    - rhsm-gtk
     - subscription-manager
-    - subscription-manager-initial-setup-addon
     - subscription-manager-plugin-ostree
     - subscription-manager-rhsm-certificates
     # asamalik: leaving out debuginfo packages, they're special and not in the repos
@@ -74,9 +66,7 @@ data:
     x86_64:
     - libdnf-plugin-subscription-manager
     - python3-subscription-manager-rhsm
-    - rhsm-gtk
     - subscription-manager
-    - subscription-manager-initial-setup-addon
     - subscription-manager-plugin-ostree
     - subscription-manager-rhsm-certificates
     # asamalik: leaving out debuginfo packages, they're special and not in the repos


### PR DESCRIPTION
subscription-manager-initial-setup-addon is deprecated, not working with
the newer Anaconda APIs, and thus being removed from RHEL 9:
https://bugzilla.redhat.com/show_bug.cgi?id=1941904

Newer versions of Anaconda can register systems during the installation,
so this is less of a concern.

rhsm-gtk is removed too, as it is build only in RHEL because
subscription-manager-initial-setup-addon is too.