### PR TITLE
Adding a builddep to sst_openstack

### DIFF
--- a/configs/sst_openstack.yaml
+++ b/configs/sst_openstack.yaml
@@ -199,6 +199,7 @@ data:
   - python3
   - python3-attrs
   - python3-babel
+  - python3-blinker
   - python3-botocore
   - python3-bson
   - python3-cffi


### PR DESCRIPTION
python3-blinker was somehow assigned to sst_openshift even though it has never shipped it nor uses it as best I can tell.  sst_openstack uses python3-oauthlib which has python3-blinker as a builddep.