### PR TITLE
sst_kernel_rats: Add sysfsutils config workload

### DIFF
--- a/configs/sst_kernel_rats-sysfsutils.yaml
+++ b/configs/sst_kernel_rats-sysfsutils.yaml
@@ -1,0 +1,12 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: sysfsutils
+  description: Utilities for interfacing with sysfs
+  maintainer: sst_kernel_rats
+  packages:
+  - glibc
+  - libsysfs 
+  labels:
+  - eln
+  - c9s


### PR DESCRIPTION
- sysfsutils needs to be included in RHEL 9.