### PR TITLE
Drop rubygem-abrt from Ruby package set.

### DIFF
--- a/configs/sst_cs_apps-ruby.yaml
+++ b/configs/sst_cs_apps-ruby.yaml
@@ -27,7 +27,6 @@ data:
   - rubygem-typeprof
   - rubygems
   - rubygems-devel
-  - rubygem-abrt
 
   labels:
   - eln


### PR DESCRIPTION
There is not ABRT in ELN (AFAIK) therefore there is no use for Ruby ABRT support.