### PR TITLE
Add an environment with empty package list for automotive and refer the same in automotive workload

### DIFF
--- a/configs/automotive-c8s-image-manifest.yaml
+++ b/configs/automotive-c8s-image-manifest.yaml
@@ -2,8 +2,8 @@
 data:
   description: Automotive CentOS image manifest packages.
   labels:
-  - centos
-  maintainer: rajesh
+  - automotive-c8s
+  maintainer: rajeshsriva
   repositories:
   - repository-c8s
   name: Automotive CentOS image manifest packages

--- a/configs/automotive-c8s-package-manifest.yaml
+++ b/configs/automotive-c8s-package-manifest.yaml
@@ -1,0 +1,73 @@
+---
+# This configuration file defines an "Environment" in Feedback Pipeline.
+# https://tiny.distro.builders
+#
+# Environments influence how a workload looks like when installed.
+# That's achieved by including specific packages — like coreutils-single — that
+# influence the result.
+# Environments can also act as base images when monitoring container sizes.
+
+document: feedback-pipeline-environment
+version: 1
+data:
+  # id is the filename — that automatically prevents collisions for free!
+
+
+  ### MANDATORY FIELDS ###
+  
+  # Name is an identifier for humans
+  #
+  # (mandatory field)
+  name: Automotive CentOS Stream package manifest.
+  
+  # A short description, perhaps hinting the purpose
+  #
+  # (mandatory field)
+  description: MVP env for automotive image based on CentOS Stream
+
+  # Who maintains it? This is just a freeform string
+  # for humans to read. In Fedora, a FAS nick is recommended.
+  #
+  # (mandatory field)
+  maintainer: rajeshsriva
+
+  # Different instances of the environment, one per repository.
+  #
+  # (mandatory field)
+  repositories:
+  - repository-c8s
+
+  # Packages defining this environment.
+  # This list includes packages for all
+  # architectures — that's the one to use by default.
+  #
+  # (mandatory field)
+  packages: []
+
+  # Labels connect things together.
+  # Workloads get installed in environments with the same label.
+  # They also get included in views with the same label.
+  # 
+  # (mandatory field)
+  labels:
+  - automotive-c8s
+
+
+  ### OPTIONAL FIELDS ###
+
+  # Architecture-specific packages.
+  #
+  # (optional field)
+  #arch_packages:
+  #  x86_64:
+  #  - arch-specific-package
+
+  # Extra installation options.
+  # The following are now supported:
+  # - "include-docs" - include documentation packages
+  # - "include-weak-deps" - automatically pull in "recommends" weak dependencies
+  #
+  # (optional field)
+  #options:
+  #- option
+


### PR DESCRIPTION
As discussed with @asamalik added an empty environment for the automotive workload based on c8s