### PR TITLE
sst_kernel_maintainers: add kernel-debug* packages to develdebug list

### DIFF
--- a/configs/sst_kernel_maintainers-kernel-develdebug.yaml
+++ b/configs/sst_kernel_maintainers-kernel-develdebug.yaml
@@ -6,8 +6,13 @@ data:
     maintainer: sst_kernel_maintainers
     packages:
         - kernel-cross-headers
-        - kernel-headers
+        - kernel-debug
+        - kernel-debug-core
+        - kernel-debug-devel
+        - kernel-debug-modules
+        - kernel-debug-modules-extra
         - kernel-devel
+        - kernel-headers
     labels:
         - eln
         - c9s


### PR DESCRIPTION
We miss the kernel-debug* packages on the list. They are being always
built on eln now, so we should list them too.

Signed-off-by: Herton R. Krzesinski <herton@redhat.com>