### PR TITLE
sst IdM: Mark custodia as unwanted

### DIFF
--- a/configs/sst_identity_management-unwanted.yaml
+++ b/configs/sst_identity_management-unwanted.yaml
@@ -37,6 +37,9 @@ data:
   # Removed dependency from IdM (https://bugzilla.redhat.com/show_bug.cgi?id=1961613)
   - python-pytest-runner
 
+  # Custodia was merged into IPA, https://pagure.io/freeipa/issue/8882
+  - custodia
+
   labels:
   - eln
   - c9s


### PR DESCRIPTION
IPA 4.9.6 no longer depends on python3-custodia.

See: https://pagure.io/freeipa/issue/8882
Signed-off-by: Christian Heimes <cheimes@redhat.com>