### PR TITLE
Update repository-c8s.yaml

### DIFF
--- a/configs/repository-c8s.yaml
+++ b/configs/repository-c8s.yaml
@@ -23,7 +23,7 @@ data:
     releasever: "8-stream"
     
     architectures:
-    #- aarch64
+    - aarch64
     #- ppc64le
     #- s390x
     - x86_64


### PR DESCRIPTION
enable `aarch64` to get included in the results for workload automotive-c8s-package-manifest