### PR TITLE
SST_PLATFORM_STORAGE Marked python-psutil as unwanted.

### DIFF
--- a/configs/sst_platform_storage-packages-unwanted.yaml
+++ b/configs/sst_platform_storage-packages-unwanted.yaml
@@ -15,6 +15,9 @@ data:
   - python-di
   - python-hs-dbus-signature
   - udisks2-zram
+  # Marking python-psutil as unwanted to remove platform_storage from
+  # consideration of ownership.
+  - python-psutil
   # - kernel-rt.0010.0055
   # sst_platform_storage owns this, but there isn't a package in Fedora.
 


### PR DESCRIPTION
This came up in a couple of threads while talking about ownership for python-psutil.  This commit will clearly indicate that we are not willing to take ownership of this component.