### PR TITLE
sst_networking: Remove ModemManager-vala from explicit list

### DIFF
--- a/configs/sst_networking-management-desktop.yaml
+++ b/configs/sst_networking-management-desktop.yaml
@@ -17,7 +17,6 @@ data:
   # Cellular Modem
   - ModemManager
   - ModemManager-glib
-  - ModemManager-vala
   - NetworkManager-ppp
   - NetworkManager-wwan
   - mobile-broadband-provider-info

--- a/configs/sst_networking-management-server.yaml
+++ b/configs/sst_networking-management-server.yaml
@@ -39,7 +39,6 @@ data:
   # Cellular Modem
   - ModemManager
   - ModemManager-glib
-  - ModemManager-vala
   - NetworkManager-ppp
   - NetworkManager-wwan
   - mobile-broadband-provider-info


### PR DESCRIPTION
`ModemManager-vala` should be in buildroot repo as it was in RHEL8
till customer requested.