### PR TITLE
Add pexpect and ptyprocess to CEE support tools

### DIFF
--- a/configs/cee-support-workload.yaml
+++ b/configs/cee-support-workload.yaml
@@ -8,6 +8,8 @@ data:
   packages:
   - sos
   - rig
+  - python3-pexpect
+  - python-ptyprocess
 
   labels:
   - eln


### PR DESCRIPTION
The python-pexpect and python-ptyprocess packages are needed by sos so
that the `collect` function of that package is functional.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>