### PR TITLE
Remove ant-apache-log4j from Apache Ant workload

### DIFF
--- a/configs/sst_cs_apps-java-ant.yaml
+++ b/configs/sst_cs_apps-java-ant.yaml
@@ -10,7 +10,6 @@ data:
   - ant-antlr
   - ant-apache-bcel
   - ant-apache-bsf
-  - ant-apache-log4j
   - ant-apache-oro
   - ant-apache-regexp
   - ant-apache-resolver


### PR DESCRIPTION
ant-apache-log4j package was removed [from Fedora](https://src.fedoraproject.org/rpms/ant/c/53cd5c1e0878eb050686e638f23a2511b8cc566c) and [from CentOS Stream](https://gitlab.com/redhat/centos-stream/rpms/ant/-/commit/99c07787fbbebbd705e3060302f4e49ac49c002a)
