### PR TITLE
SST_PLATFORM_STORAGE: Marked rust-packaging as unwanted.

### DIFF
--- a/configs/sst_platform_storage-packages-unwanted.yaml
+++ b/configs/sst_platform_storage-packages-unwanted.yaml
@@ -15,9 +15,10 @@ data:
   - python-di
   - python-hs-dbus-signature
   - udisks2-zram
-  # Marking python-psutil as unwanted to remove platform_storage from
+  # Marking these packages as unwanted to remove platform_storage from
   # consideration of ownership.
   - python-psutil
+  - rust-packaging
   # - kernel-rt.0010.0055
   # sst_platform_storage owns this, but there isn't a package in Fedora.
 


### PR DESCRIPTION
This package should not be tagged against platform_storage as there are no more dependencies.