### PR TITLE
sst_filesystems: Add unwanted packages

### DIFF
--- a/configs/sst_filesystems-userspace-unwanted.yaml
+++ b/configs/sst_filesystems-userspace-unwanted.yaml
@@ -7,6 +7,10 @@ data:
 
   unwanted_packages:
     - system-storage-manager
+    - xmlstarlet
+    - oath-toolkit
+    - luarocks
+    - leveldb
 
   unwanted_arch_packages:
     aarch64:


### PR DESCRIPTION
These packages were assigned to sst_filesystems as the dependencies for
ceph in RHEL 9 but we no longer require these to build ceph, marking
them as unwanted.

Signed-off-by: Boris Ranto <branto@redhat.com>