### PR TITLE
Add oval-graph to sst_security_compliance unwanted

### DIFF
--- a/configs/sst_security_compliance-unwanted.yaml
+++ b/configs/sst_security_compliance-unwanted.yaml
@@ -23,3 +23,6 @@ data:
     - libtnc
     - tncfhh
     - petera
+
+    # this utility should not be included at this moment
+    - oval-graph


### PR DESCRIPTION
- Add `oval-graph` to list of unwanted packages
- `oval-graph` will be repurposed and its inclusion is postponed