### PR TITLE
sst_filesystems: Add fmt to unwanted packages

### DIFF
--- a/configs/sst_filesystems-userspace-unwanted.yaml
+++ b/configs/sst_filesystems-userspace-unwanted.yaml
@@ -11,6 +11,7 @@ data:
     - oath-toolkit
     - luarocks
     - leveldb
+    - fmt
 
   unwanted_arch_packages:
     aarch64:


### PR DESCRIPTION
This package was assigned to  sst_filesystems as the dependency for ceph
in RHEL 9. We managed to remove that dependency so I am marking the
package as unwanted.

Signed-off-by: Boris Ranto <branto@redhat.com>