### PR TITLE
Rename kernel-abi-whitelists -> kernel-abi-stablelists

### DIFF
--- a/configs/sst_kernel_maintainers-kernel-base.yaml
+++ b/configs/sst_kernel_maintainers-kernel-base.yaml
@@ -20,7 +20,7 @@ data:
         - iwl6050-firmware
         - iwl7260-firmware
         - kernel
-        - kernel-abi-whitelists
+        - kernel-abi-stablelists
         - kernel-core
         - kernel-cross-headers
         - kernel-doc


### PR DESCRIPTION
Signed-off-by: Cestmir Kalina <ckalina@redhat.com>