### PR TITLE
Add bcc-tools to the tracing workload

### DIFF
--- a/configs/sst_kernel_tps-tracing.yaml
+++ b/configs/sst_kernel_tps-tracing.yaml
@@ -7,6 +7,7 @@ data:
 
   packages:
   - bcc
+  - bcc-tools
   - strace
   - trace-cmd
   - libtracefs


### PR DESCRIPTION
Bcc-tools package is missing from the compose since we replaced the
hard dependancy on bcc-tools from bcc package by a soft one
(Recommends). Let's add it explicitly to the workload.

Resolves: rhbz#1991897