### PR TITLE
Add kernel-*devel-matched packages to the content resolver

### DIFF
--- a/configs/sst_kernel_maintainers-kernel-develdebug.yaml
+++ b/configs/sst_kernel_maintainers-kernel-develdebug.yaml
@@ -9,9 +9,11 @@ data:
         - kernel-debug
         - kernel-debug-core
         - kernel-debug-devel
+        - kernel-debug-devel-matched
         - kernel-debug-modules
         - kernel-debug-modules-extra
         - kernel-devel
+        - kernel-devel-matched
         - kernel-headers
     labels:
         - eln
@@ -25,4 +27,5 @@ data:
             - kernel-tools-libs-devel
         s390x:
             - kernel-zfcpdump-devel
+            - kernel-zfcpdump-devel-matched
 


### PR DESCRIPTION
These are new packages introduced recently in kernel-ark/Fedora, and
synced to RHEL 9 already. They are empty meta packages that requires both
the core and devel packages locked on the same version. For reference,
this is the MR which added them:
https://gitlab.com/cki-project/kernel-ark/-/merge_requests/1195

Signed-off-by: Herton R. Krzesinski <herton@redhat.com>