### PR TITLE
Add libdecor

### DIFF
--- a/configs/sst_graphics_infrastructure-graphics-development-libraries.yaml
+++ b/configs/sst_graphics_infrastructure-graphics-development-libraries.yaml
@@ -6,6 +6,7 @@ data:
   maintainer: sst_graphics_infrastructure
 
   packages:
+    - libdecor
     - SDL
     - SDL2
 


### PR DESCRIPTION
Libdecor is a new dependency of SDL2; add it to the same config as SDL2.

Signed-off-by: Jonas Ådahl <jadahl@redhat.com>