### PR TITLE
sst_coreos: correct maintainer

### DIFF
--- a/configs/sst_coreos.yaml
+++ b/configs/sst_coreos.yaml
@@ -5,7 +5,7 @@ data:
   description: >
     OS compontents for CoreOS based systems.
     This should be distributed via ostrees.
-  maintainer: sst_rhcos
+  maintainer: coreos
 
   packages:
    # These packages are currently built and released as part of


### PR DESCRIPTION
There is no `sst_rhcos`, but instead the label for the CoreOS SST is
just `coreos`.