### PR TITLE
sst_networking: Add libqrtr-glib which is required by ModemManager

### DIFF
--- a/configs/sst_networking-management-desktop.yaml
+++ b/configs/sst_networking-management-desktop.yaml
@@ -19,6 +19,7 @@ data:
   - ModemManager-glib
   - NetworkManager-ppp
   - NetworkManager-wwan
+  - libqrtr-glib
   - mobile-broadband-provider-info
   - usb_modeswitch
   - usb_modeswitch-data

--- a/configs/sst_networking-management-devel.yaml
+++ b/configs/sst_networking-management-devel.yaml
@@ -17,6 +17,7 @@ data:
   - NetworkManager-libnm-devel
   - ModemManager-devel
   - ModemManager-glib-devel
+  - libqrtr-glib-devel
 
   labels:
   - eln

--- a/configs/sst_networking-management-server.yaml
+++ b/configs/sst_networking-management-server.yaml
@@ -41,6 +41,7 @@ data:
   - ModemManager-glib
   - NetworkManager-ppp
   - NetworkManager-wwan
+  - libqrtr-glib
   - mobile-broadband-provider-info
   - usb_modeswitch
   - usb_modeswitch-data


### PR DESCRIPTION
The 5G communication require new version of ModemManager which need
libqrtr-glib.