### PR TITLE
sst_coreos: Update package list for C9S

### DIFF
--- a/configs/sst_coreos.yaml
+++ b/configs/sst_coreos.yaml
@@ -8,30 +8,31 @@ data:
   maintainer: sst_rhcos
 
   packages:
-   # These packages are currently built and released as part of
-   # OpenShift 4 (RHCOS).  In the future we may create ELN CoreOS,
-   # see https://github.com/coreos/fedora-coreos-config/pull/712
-   - afterburn
-   - afterburn-dracut
-   - coreos-installer
-   - ignition
-   - runc
-   - ssh-key-dir
-   - zincati
-   - bootupd
+  - afterburn
+  - afterburn-darcut
+  - butane
+  - console-login-helper-messages-issuegen
+  - console-login-helper-messages-motdgen
+  - console-login-helper-messages-profile
+  - ignition
+  - ignition-validate
+  - ssh-key-dir
 
-   # These packages are inherited from the base
-   - cloud-utils-growpart
-   - console-login-helper-messages-issuegen
-   - console-login-helper-messages-motdgen
-   - console-login-helper-messages-profile
-   - ostree
-   - podman
-   - rpm-ostree
-   - skopeo
-   - systemd-container
-   - toolbox
+  # Packages co-maintained with the Edge SST
+  - ostree
+  - rpm-ostree
+  - nss-altfiles
+  - coreos-installer
+  - coreos-installer-bootinfra
+  - coreos-installer-dracut
 
-## Do not re-enable in eln without Josh Boyers permission
-  labels: []
-#  - eln
+  arch_packages:
+    x86_64:
+    - bootupd
+    aarch64:
+    - bootupd
+
+  # Do not re-enable in eln without Josh Boyers permission
+  labels:
+  # - eln
+  - c9s

--- a/configs/sst_edge.yaml
+++ b/configs/sst_edge.yaml
@@ -10,7 +10,6 @@ data:
   - greenboot
   - greenboot-reboot
   - greenboot-status
-  - ignition
   - libgpiod-devel
   - libgpiod-utils
   - python3-libgpiod
@@ -18,10 +17,14 @@ data:
   - libiio-devel
   - libiio-utils
   - python3-iio
+
+  # Packages co-maintained with the CoreOS SST
   - ostree
   - rpm-ostree
   - nss-altfiles
   - coreos-installer
+  - coreos-installer-bootinfra
+  - coreos-installer-dracut
 
   arch_packages:
     x86_64:
@@ -37,4 +40,3 @@ data:
   labels:
   - eln
   - c9s
-


### PR DESCRIPTION
- Enable C9S for the CoreOS SST
- Add package: butane
- Add sub-packages:
    - coreos-installer-bootinfra
    - coreos-installer-dracut
    - ignition-validate
- Mark bootupd as x86-64 & aarch64 only
- Clarify the list of packages co-maintained with the Edge SST
- Remove packages effectively maintained by other SSTs
- Remove ignition from the Edge SST