### PR TITLE
Add redhat-fonts package for RHEL9+

### DIFF
--- a/configs/sst_i18n-extra-fonts.yaml
+++ b/configs/sst_i18n-extra-fonts.yaml
@@ -13,6 +13,7 @@ data:
   - google-noto-serif-gurmukhi-vf-fonts
   - google-noto-serif-sinhala-vf-fonts
   - liberation-narrow-fonts
+  - redhat-fonts
   - smc-rachana-fonts
 
   labels:


### PR DESCRIPTION
The sst_i18n group would like to add redhat-fonts package in RHEL9+ releases.

