### PR TITLE
Split sst_front_door into installer/image_builder/cockpit

### DIFF
--- a/configs/sst_cockpit-podman.yaml
+++ b/configs/sst_cockpit-podman.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Podman Web Console UI
   description: Cockpit page for podman administration
-  maintainer: sst_front_door
+  maintainer: sst_cockpit
   labels:
     - eln
     - c9s

--- a/configs/sst_cockpit-unwanted.yaml
+++ b/configs/sst_cockpit-unwanted.yaml
@@ -1,0 +1,16 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Unwanted Packages -- sst_cockpit
+  description: Packages that should not be distributed in RHEL 9
+  maintainer: sst_cockpit
+  labels:
+    - eln
+    - c9s
+
+  unwanted_packages:
+    # mpitt: only needed for integration tests (buildroot), never ship this
+    - cockpit-tests
+
+    # mpitt: Will be deprecated soon, let's not introduce it
+    - cockpit-dashboard

--- a/configs/sst_cockpit-web-console.yaml
+++ b/configs/sst_cockpit-web-console.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Web Console (Cockpit)
   description: Cockpit basic packages
-  maintainer: sst_front_door
+  maintainer: sst_cockpit
   labels:
     - eln
     - c9s
@@ -16,7 +16,7 @@ data:
     - cockpit-storaged
     - cockpit-pcp
     - cockpit-doc
-    
+
   arch_packages:
     aarch64:
     # extensions maintained by Cockpit team

--- a/configs/sst_image_builder-composer.yaml
+++ b/configs/sst_image_builder-composer.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Composer Web Console UI
   description: Cockpit page for composer
-  maintainer: sst_front_door
+  maintainer: sst_image_builder
   labels:
     - eln
     - c9s

--- a/configs/sst_image_builder-weldr-client.yaml
+++ b/configs/sst_image_builder-weldr-client.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: composer-cli weldr client
   description: composer-cli command line utility to control osbuild-composer
-  maintainer: sst_front_door
+  maintainer: sst_image_builder
   labels:
     - eln
     - c9s

--- a/configs/sst_installer-anaconda.yaml
+++ b/configs/sst_installer-anaconda.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Anaconda
   description: Graphical system installer
-  maintainer: sst_front_door
+  maintainer: sst_installer
   labels:
     - eln
     - c9s

--- a/configs/sst_installer-unwanted.yaml
+++ b/configs/sst_installer-unwanted.yaml
@@ -1,20 +1,14 @@
 document: feedback-pipeline-unwanted
 version: 1
 data:
-  name: Unwanted Packages -- sst_front_door
+  name: Unwanted Packages -- sst_installer
   description: Packages that should not be distributed in RHEL 9
-  maintainer: sst_front_door
+  maintainer: sst_installer
   labels:
     - eln
     - c9s
 
   unwanted_packages:
-    # mpitt: only needed for integration tests (buildroot), never ship this
-    - cockpit-tests
-
-    # mpitt: Will be deprecated soon, let's not introduce it
-    - cockpit-dashboard
-
     # Radek Vykydal:
     # system-config-kickstart has been deprecated upstream, it has not
     # been ported to Python 3, and shouldn't have been included in RHEL 8.

--- a/configs/sst_installer-x3270.yaml
+++ b/configs/sst_installer-x3270.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: x3270
   description: IBM 3278/3279 terminal emulator for the X Window System
-  maintainer: sst_front_door
+  maintainer: sst_installer
   labels:
     - eln
     - c9s


### PR DESCRIPTION
The previous sst_front_door got changed into an ssg_front_door group
with individual to sst_cockpit, sst_image_builder and sst_installer
teams.