### PR TITLE
Added a CI workflow

### DIFF
--- a/.github/workflows/config-check.yml
+++ b/.github/workflows/config-check.yml
@@ -1,0 +1,52 @@
+name: Check of config files
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  setup_and_test:
+    runs-on: ubuntu-latest
+    container: 
+      image: registry.fedoraproject.org/fedora:35
+    steps:
+    
+    - name: Checkout code repo
+      uses: actions/checkout@v2
+      with:
+        repository: minimization/content-resolver
+        path: code
+    
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        path: code/input
+        
+    - name: Install git and Python libraries
+      run: dnf -y install git-core python3-yaml python3-jinja2 python3-pytest python3-flake8
+
+    # GitHub Actions is unable to process multiline comments, this sanitization helps with the problem as described here: https://trstringer.com/github-actions-multiline-strings/    
+    - name: Run get_configs and set output
+      run: |
+        cd code
+        RESULTS=$(python3 test_config_files.py 2>&1)
+        RESULTS="${RESULTS//'%'/'%25'}"
+        RESULTS="${RESULTS//$'\n'/'%0A'}"
+        RESULTS="${RESULTS//$'\r'/'%0D'}"
+        echo "::set-output name=PR_COMMENT::$RESULTS"
+      id: get_configs_output
+    
+    # The output is inserted as a multiline code block into the body of pull request comment 
+    - name: Comment on the PR
+      uses: actions/github-script@v5
+      with: 
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `\`\`\`\n${{ steps.get_configs_output.outputs.PR_COMMENT }}\n\`\`\``   
+          })


### PR DESCRIPTION
Hi @asamalik!

Here's the GitHub Actions workflow for CI for testing the config files. 

The CI checks the config files using `test_config_files.py` from the code repository content-resolver. It then prints the output to a body of PR comment. Which means you should be able to see if the checks passed right away. Here's a demonstration: https://github.com/regexowl/content-resolver-input/pull/50

The `test_config_files.py` runs the `get_configs` function from the `feedback_pipeline.py` to check the configs, so all the code stays in one place.

Let me know what you think :)