### PR TITLE
Fix the sst_coreos.yaml

### DIFF
--- a/configs/sst_coreos.yaml
+++ b/configs/sst_coreos.yaml
@@ -33,5 +33,5 @@ data:
    - toolbox
 
 ## Do not re-enable in eln without Josh Boyers permission
-#  labels:
+  labels: []
 #  - eln


### PR DESCRIPTION
The 'labels' field is mandatory, so I just set it as empty so it does what it was supposed to, but without failing.