### PR TITLE
Remove a placeholder for compat-libtiff3 as this package is no longer needed

### DIFF
--- a/configs/sst_cs_apps-images-compat.yaml
+++ b/configs/sst_cs_apps-images-compat.yaml
@@ -8,20 +8,5 @@ data:
   packages:
   - libpng15
 
-  package_placeholders:
-    compat-libtiff3:
-      description: Compatibility package for libtiff 3
-      requires:
-      - libgcc
-      - libjpeg-turbo
-      - libstdc++
-      - zlib
-      buildrequires:
-      - autoconf
-      - automake
-      - libjpeg-turbo-devel
-      - libtool
-      - zlib-devel
-
   labels:
   - c9s


### PR DESCRIPTION
See more at https://bugzilla.redhat.com/show_bug.cgi?id=1990361