### PR TITLE
Fix typo in unwanted packages list for autoconf213

### DIFF
--- a/configs/sst_desktop_applications-unwanted-eln.yaml
+++ b/configs/sst_desktop_applications-unwanted-eln.yaml
@@ -34,7 +34,7 @@ data:
   - libgdl
   - libmusicbrainz5
   # Vendored to mozjs78 and Firefox and Thunderbird
-  - autoconf231
+  - autoconf213
   # Miners are mostly broken and other problems
   # https://bugzilla.redhat.com/show_bug.cgi?id=1913643
   - gnome-online-miners

--- a/configs/sst_desktop_applications-unwanted.yaml
+++ b/configs/sst_desktop_applications-unwanted.yaml
@@ -30,7 +30,7 @@ data:
   - libgdl
   - libmusicbrainz5
   # Vendored to mozjs78 and Firefox and Thunderbird
-  - autoconf231
+  - autoconf213
   # Miners are mostly broken and other problems
   # https://bugzilla.redhat.com/show_bug.cgi?id=1913643
   - gnome-online-miners


### PR DESCRIPTION
There was only ever an autoconf213 for mozjs78, firefox
and thunderbird. The use of autoconf231 is a typo (transposed
1 and 3) in the unwanted packages lists. Fixing unwanted packages
is important because we do not want autoconf213 to continue to be
used as a compat package.