### PR TITLE
Mark libXpresent as unwanted by sst_subman

### DIFF
--- a/configs/sst_subscription_manager-subscription-manager.yaml
+++ b/configs/sst_subscription_manager-subscription-manager.yaml
@@ -8,6 +8,9 @@ data:
   packages:
     - subscription-manager-cockpit
     - rhsm-icons
+  
+  unwanted_packages:
+  - libXpresent
 
   labels:     
   - eln       


### PR DESCRIPTION
This PR adds the optional "unwanted_packages" entry to the sst_subscription_manager config in order to mark libXpresent as unwanted.