### PR TITLE
Mark plotnetcfg as unwanted

### DIFF
--- a/configs/sst_networking-tools-plotnetcfg.yaml
+++ b/configs/sst_networking-tools-plotnetcfg.yaml
@@ -5,7 +5,7 @@ data:
   description: >
     Packages related to network configuration and troubleshooting.
   maintainer: sst_networking
-  packages:
+  unwanted_packages:
   - plotnetcfg
 
   labels:


### PR DESCRIPTION
The Skydive service is a better alternative for exploring complex
OpenStack/Kubernetes network topology. The plotnetcfg tool is useful mostly
for the kernel developers. It's not actively maintained upstream at the
moment.