### PR TITLE
Add gnome-shell-extension-background-logo to ELN/RHEL9

### DIFF
--- a/configs/sst_desktop-gnome-desktop-eln.yaml
+++ b/configs/sst_desktop-gnome-desktop-eln.yaml
@@ -21,6 +21,7 @@ data:
   - gnome-session
   - gnome-shell
   - gnome-shell-extension-auto-move-windows
+  - gnome-shell-extension-background-logo
   - gnome-shell-extension-common
   - gnome-shell-extension-drive-menu
   - gnome-shell-extension-native-window-placement

--- a/configs/sst_desktop-gnome-desktop.yaml
+++ b/configs/sst_desktop-gnome-desktop.yaml
@@ -25,6 +25,7 @@ data:
   - gnome-session
   - gnome-shell
   - gnome-shell-extension-auto-move-windows
+  - gnome-shell-extension-background-logo
   - gnome-shell-extension-common
   - gnome-shell-extension-drive-menu
   - gnome-shell-extension-native-window-placement


### PR DESCRIPTION
Package will be used in RHEL 9 to display RH logo.