### PR TITLE
Include documentation and skopeo

### DIFF
--- a/configs/automotive-workload-off.yaml
+++ b/configs/automotive-workload-off.yaml
@@ -11,6 +11,8 @@ data:
   maintainer: automotive-base-enablement
   labels:
     - automotive
+  options:
+    - include-docs
   packages:
     - acl
     - bc

--- a/configs/automotive-workload-off.yaml
+++ b/configs/automotive-workload-off.yaml
@@ -73,6 +73,7 @@ data:
     - redhat-rpm-config
     - rpm-build
     - sed
+    - skopeo
     - strace
     - sudo
     - tar


### PR DESCRIPTION
This PR includes two changes, one to include skopeo in the set to re-enable osbuild with the updated templates, the other to include documentation in the automotive repository to address functional safety requirements.