### PR TITLE
Update ELN configs for .NET

### DIFF
--- a/configs/sst_dotnet_java-dotnet.yaml
+++ b/configs/sst_dotnet_java-dotnet.yaml
@@ -8,24 +8,18 @@ data:
   packages: []
   
   arch_packages:
-    x86_64:
-    - dotnet-sdk-3.1
-    - dotnet-runtime-3.1
-    - aspnetcore-runtime-3.1
     aarch64:
-    - dotnet-sdk-3.1
-    - dotnet-runtime-3.1
-    - aspnetcore-runtime-3.1
-
-  package_placeholders:
-    dotnet-sdk-6.0:
-      srpm: dotnet6.0
-      description: .NET 6.0 doesn't exist, yet, but it's being planned for release in Nov 2021.
-      limit_arches:
-      - x86_64
-      - aarch64
-      requires: []        # same dependencies as dotnet-sdk-3.1
-      buildrequires: []   # same dependencies as dotnet-sdk-3.1
+    - dotnet-sdk-6.0
+    - dotnet-runtime-6.0
+    - aspnetcore-runtime-6.0
+    s390x:
+    - dotnet-sdk-6.0
+    - dotnet-runtime-6.0
+    - aspnetcore-runtime-6.0
+    x86_64:
+    - dotnet-sdk-6.0
+    - dotnet-runtime-6.0
+    - aspnetcore-runtime-6.0
 
   labels:
   - eln

--- a/configs/sst_dotnet_java-unwanted.yaml
+++ b/configs/sst_dotnet_java-unwanted.yaml
@@ -9,6 +9,10 @@ data:
   - c9s
 
   unwanted_packages:
+  # We do not want to ship .NET Core 3.1 which will be EOL by late 2022
+  - dotnet-sdk-3.1
+  - dotnet-runtime-3.1
+  - aspnetcore-runtime-3.1
   # We do not want to ship .NET 5.0 which will be EOL by early 2022
   - dotnet-sdk-5.0
   - dotnet-runtime-5.0


### PR DESCRIPTION
Now that .NET 6 is available, move it from placeholders into main list
of packages. And move .NET Core 3.1, which was a placeholder too, into
unwanted.