### PR TITLE
Add more log4j subpackages to log4j workload

### DIFF
--- a/configs/sst_cs_apps-java-log4j.yaml
+++ b/configs/sst_cs_apps-java-log4j.yaml
@@ -7,6 +7,8 @@ data:
 
   packages:
   - log4j
+  - log4j-jcl
+  - log4j-slf4j
 
   labels:
   - c9s


### PR DESCRIPTION
log4j-jcl and log4j-slf4j subpackages of log4j should also be in AppStream in CS 9 and ELN.