### PR TITLE
Remove rootfiles from the Automotive environment

### DIFF
--- a/configs/automotive-environment.yaml
+++ b/configs/automotive-environment.yaml
@@ -48,7 +48,6 @@ data:
     - podman
     - procps-ng
     - rng-tools
-    - rootfiles
     - rpm-ostree
     - rsyslog
     - selinux-policy-targeted

--- a/configs/automotive-workload-off.yaml
+++ b/configs/automotive-workload-off.yaml
@@ -73,6 +73,7 @@ data:
     - python-unversioned-command
     - qemu-img
     - redhat-rpm-config
+    - rootfiles
     - rpm-build
     - sed
     - skopeo


### PR DESCRIPTION
Moving this to the off-vehicle workload.  We don't expect interactive
root shell sessions to be happening in vehicle.

Signed-off-by: Petr Šabata <contyk@redhat.com>