### PR TITLE
Automotive: Drop rng-tools from the environment

### DIFF
--- a/configs/automotive-environment.yaml
+++ b/configs/automotive-environment.yaml
@@ -46,7 +46,6 @@ data:
     - passwd
     - podman
     - procps-ng
-    - rng-tools
     - rpm-ostree
     - rsyslog
     - selinux-policy-targeted

--- a/configs/automotive-workload-off.yaml
+++ b/configs/automotive-workload-off.yaml
@@ -73,6 +73,7 @@ data:
     - python-unversioned-command
     - qemu-img
     - redhat-rpm-config
+    - rng-tools
     - rootfiles
     - rpm-build
     - sed


### PR DESCRIPTION
The platform is expected to provide a hardware RNG.  We're still
including rng-tools in the off vehicle set as a fallback, especially for
image builds.

Signed-off-by: Petr Šabata <contyk@redhat.com>