### PR TITLE
Add initial ELN Extras workload for Meta

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -1,0 +1,23 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: meta-sig packages
+  description: ELN Extras packages that Meta cares about
+  maintainer: meta-sig
+
+  packages:
+  - atop
+  - ccache
+  - dbench
+  - et
+  - htop
+  - fping
+  - mosh
+  - neovim
+  - ngrep
+  - screen
+  - sdparm
+  - stress
+
+  labels:
+  - eln-extras


### PR DESCRIPTION
This is an initial set of packages that we (myself and @michel-slm, with our Meta hats on) would like to track for ELN. We're happy to sign up for keeping these in good shape. I put the placeholder FAS group we have for this (which is currently just used for copr, it's not a real SIG nor it plans to be) as maintainer, as it seemed better than just listing individuals.

This is just an initial package set to test how the process works and we plan to augment it down the road.