### PR TITLE
Add initial ELN Extras workload for the CentOS Hyperscale SIG

### DIFF
--- a/configs/eln_extras_hyperscale.yaml
+++ b/configs/eln_extras_hyperscale.yaml
@@ -1,0 +1,15 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: hyperscale packages
+  description: ELN Extras packages that the CentOS Hyperscale SIG cares about
+  maintainer: sig-hyperscale
+
+  packages:
+  - btrfs-fuse
+  - centos-packager
+  - fsverity-utils
+  - mock-centos-sig-configs
+
+  labels:
+  - eln-extras


### PR DESCRIPTION
This is an initial set of packages that the [CentOS Hyperscale SIG](https://sigs.centos.org/hyperscale/) depends upon and/or cares about and would like to see tracked in ELN. We're happy to sign up for keeping these in good shape, I put the SIG FAS group as the maintainer.