### PR TITLE
Automotive package cleanup

### DIFF
--- a/configs/automotive-environment.yaml
+++ b/configs/automotive-environment.yaml
@@ -32,11 +32,7 @@ data:
     - glibc
     - glibc-gconv-extra
     - glibc-langpack-en
-    - greenboot-grub2
-    - greenboot-reboot
-    - greenboot-rpm-ostree-grub2
-    - greenboot-status
-    - grub2
+    - greenboot
     - hostapd
     - hostname
     - jose

--- a/configs/automotive-workload-off.yaml
+++ b/configs/automotive-workload-off.yaml
@@ -48,7 +48,6 @@ data:
     - glibc-devel
     - harfbuzz
     - harfbuzz-devel
-    - hmaccalc
     - inih
     - jq
     - kpartx
@@ -111,8 +110,6 @@ data:
     - xfsprogs
     - xz
     - xz-devel
-    - yasm
-    - yasm-devel
     - yum
     - zlib-devel
     - zstd


### PR DESCRIPTION
Remove packages not available in Stream or CBS, namely yasm and
hmaccalc.  Additionally, drop fake packages such as grub2 and
greenboot-*.  These don't really exist at this point.

grub2 functionality is provided by the arch-dependent packages, while
the greenboot package provides the commands previously listed as
explicit packages.

With this commit, everything is either in Stream or CBS.

Signed-off-by: Petr Šabata <contyk@redhat.com>