### PR TITLE
Add in lvm2 to the automotive content resolver 

### DIFF
--- a/configs/automotive-environment.yaml
+++ b/configs/automotive-environment.yaml
@@ -45,6 +45,7 @@ data:
     - libwebp
     - libzstd
     - luksmeta
+    - lvm2
     - NetworkManager
     - nftables
     - nss-altfiles


### PR DESCRIPTION
the LVM2 is needed for crypt work and to allow for other pipeline items to go ahead.