### PR TITLE
automotive-repositories: switch to production c9s composes

### DIFF
--- a/configs/automotive-repositories-c9s.yaml
+++ b/configs/automotive-repositories-c9s.yaml
@@ -5,29 +5,27 @@ data:
   name: Standard Automotive repositories based on C9S
   description: >
     C9S Repositories for Base Autopackages (BaseOS, AppStream,
-    PowerTools, Extras, EPEL, EPEL-Next, Neptune)
+    PowerTools, CBS AutoSD packages, CBS Automotive packages,
+    Neptune)
   # Contacts: psabata, ssmoogen
   maintainer: automotive-base-enablement
   source:
     repos:
+      cbs-autosd:
+        baseurl: https://buildlogs.centos.org/9-stream/autosd/$basearch/packages-main/
+        priority: 0
+      cbs-automotive:
+        baseurl: https://buildlogs.centos.org/9-stream/automotive/$basearch/packages-main/
+        priority: 50
       stream-baseos:
         baseurl: https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/BaseOS/$basearch/os/
-        priority: 0
+        priority: 100
       stream-appstream:
         baseurl: https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/AppStream/$basearch/os/
-        priority: 0
+        priority: 100
       stream-powertools:
         baseurl: https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/CRB/$basearch/os/
-        priority: 0
-      buildroot:
-        baseurl: https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/$basearch/
         priority: 100
-      epel9-next:
-        baseurl: https://dl.fedoraproject.org/pub/epel/next/9/Everything/$basearch/
-        priority: 200
-      cbs:
-        baseurl: https://buildlogs.centos.org/9-stream/automotive/$basearch/packages-main/
-        priority: 250
       neptune:
         baseurl: https://download.copr.fedorainfracloud.org/results/pingou/qtappmanager-fedora/centos-stream-9-$basearch/
         priority: 500


### PR DESCRIPTION
Switches the CS9 repositories to the production compose as the
development compose is unstable. Currently the annobin packages in the
development compose have bugs that block it from reaching the production
compose and is a case where we would be introducing a buggy state by
using the development compose as an input.
    
Also drops buildroot and epel as we don't want to introduce non c9s
content into the AutoSD distribution by default.
    
Also adds the autosd CBS packages and shift that plus the Automotive CBS
packages to a higher priority layer (would make sense that what they fork
take priority over C9S).