### PR TITLE
Add cppcheck.

### DIFF
--- a/configs/automotive-workload-off.yaml
+++ b/configs/automotive-workload-off.yaml
@@ -27,6 +27,7 @@ data:
     - chrony
     - cmake
     - cpio
+    - cppcheck
     - curl
     - dhcp-client
     - diffutils


### PR DESCRIPTION
Hello,

This pull request is for my branch in my forked content-resolver-input repo, adding cppcheck package to the off-vehicle workload.  This is needed in order for CentOS 9 Stream Automotive SIG to include cppcheck package.  AUTOSAR C++ Coding Guidelines call for the OS to include a static analysis tool.

Thanks,

Steve Dunnagan