### PR TITLE
Drop gtk2 and gnome-common from ELN/RHEL 10+

### DIFF
--- a/configs/sst_desktop-gtk2.yaml
+++ b/configs/sst_desktop-gtk2.yaml
@@ -11,5 +11,4 @@ data:
   - gtk2-immodules
 
   labels:
-  - eln
   - c9s

--- a/configs/sst_desktop-unwanted-eln.yaml
+++ b/configs/sst_desktop-unwanted-eln.yaml
@@ -83,5 +83,7 @@ data:
   - adwaita-gtk2-theme
   # Only GUI application stuck with GTK 2, also no interest in maintaining an IRC client
   - hexchat
+  # https://wiki.gnome.org/Initiatives/GnomeGoals/GettextMigration
+  - gnome-common
   labels:
   - eln

--- a/configs/sst_desktop-unwanted-eln.yaml
+++ b/configs/sst_desktop-unwanted-eln.yaml
@@ -77,5 +77,11 @@ data:
   - tracker3-miners
   # libhandy1 renamed to libhandy in F34+
   - libhandy1
+  # only GTK 3 and GTK 4 supported in ELN and RHEL 10
+  - gtk2
+  - gtk2-immodules
+  - adwaita-gtk2-theme
+  # Only GUI application stuck with GTK 2, also no interest in maintaining an IRC client
+  - hexchat
   labels:
   - eln


### PR DESCRIPTION
gtk2:
GTK 2 served us for a long time, but it's time to say good bye to it.
Applications had plenty of time to move to newer toolkits that support
the current technologies (Wayland, HiDPI displays, ..).

gnome-common:
Applications had plenty of time to move away from intltool to gettext
and the packages that currently require it in ELN are on their way to
drop the gnome-common dependency.

RH Internal tracking issue: https://issues.redhat.com/browse/DESKTOP-481