### PR TITLE
Add libkdumpfile-devel to ELN Extras for Meta workload

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -14,6 +14,7 @@ data:
   - et
   - htop
   - fping
+  - libkdumpfile-devel
   - mosh
   - neovim
   - netconsd


### PR DESCRIPTION
This is needed to be able to build drgn on ELN in PackIt (see https://github.com/osandov/drgn/issues/188).