### PR TITLE
Add initially only NetworkManager-openvpn-gnome to ELN extras

### DIFF
--- a/configs/eln_extras_pablomh.yaml
+++ b/configs/eln_extras_pablomh.yaml
@@ -1,0 +1,12 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: pablomh packages
+  description: Pablo Méndez Hernández ELN Extras packages
+  maintainer: pablomh
+
+  packages:
+  - NetworkManager-openvpn-gnome
+
+  labels:
+  - eln-extras


### PR DESCRIPTION
This way we can configure OpenVPN from Gnome.