### PR TITLE
Drop eln from RHEL 7 ACG1 list

### DIFF
--- a/configs/acg-level1-el7.yaml
+++ b/configs/acg-level1-el7.yaml
@@ -2,8 +2,6 @@
 data:
   description: Automatically generated.
   labels:
-  - eln-candidate
-  - eln
   - c9s
   maintainer: bakery
   name: ACG Level 1 Packages for RHEL 7


### PR DESCRIPTION
ELN is tracking RHEL 10, which is not affected by RHEL 7's ACG level-1 list.