### PR TITLE
python3-toml is unwnated but was also required

### DIFF
--- a/configs/sst_cs_apps-python-data-formats-c9s.yaml
+++ b/configs/sst_cs_apps-python-data-formats-c9s.yaml
@@ -1,0 +1,14 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Python parsers
+  description: Python packages for parsing common data formats
+  maintainer: sst_cs_apps
+
+  packages:
+  - python3-lxml
+  - python3-pyyaml
+  - python3-toml
+
+  labels:
+  - c9s

--- a/configs/sst_cs_apps-python-data-formats-eln.yaml
+++ b/configs/sst_cs_apps-python-data-formats-eln.yaml
@@ -12,4 +12,3 @@ data:
 
   labels:
   - eln
-  - c9s

--- a/configs/sst_cs_apps-python-data-formats-eln.yaml
+++ b/configs/sst_cs_apps-python-data-formats-eln.yaml
@@ -8,7 +8,6 @@ data:
   packages:
   - python3-lxml
   - python3-pyyaml
-  - python3-toml
 
   labels:
   - eln


### PR DESCRIPTION
See d70542ac44b9beb5502347550ee7395c7a674afd

## Question

Do I need to create a copy of this file for c9s only that has python3-toml because python3-toml is still wanted there, or do I need to remove to c9s label, or do I not care about c9s here, because packages are never removed from there?