### PR TITLE
include libgpiod and libi2c in automotive

### DIFF
--- a/configs/automotive-environment.yaml
+++ b/configs/automotive-environment.yaml
@@ -40,6 +40,8 @@ data:
     - kernel-automotive
     - linux-firmware-automotive
     - libcurl
+    - libgpiod
+    - libi2c
     - libstdc++
     - libvorbis
     - libwebp


### PR DESCRIPTION
include libgpiod and libi2c in automotive

Signed-off-by: Brian Masney <bmasney@redhat.com>