### PR TITLE
Create RHEL packager workload (converted from pablomh workload)

### DIFF
--- a/configs/eln_extras_rhel_packager.yaml
+++ b/configs/eln_extras_rhel_packager.yaml
@@ -1,12 +1,13 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: pablomh packages
-  description: Pablo Méndez Hernández ELN Extras packages
-  maintainer: pablomh
+  name: RHEL packager
+  description: ELN Extras packages for RHEL maintainers
+  maintainer: carlwgeorge
 
   packages:
   - NetworkManager-openvpn-gnome
+  - centpkg
 
   labels:
   - eln-extras


### PR DESCRIPTION
During the early days of CentOS Stream bootstrapping, it is useful for RHEL maintainers to be able to dogfood it (use the distro to develop the distro).  Let's add a specific workload for this to ensure the necessary packages stay compatible.

I spoke with @pablomh about this already over email, and he agreed to allow us to repurpose his single-package workload since it already contained one of the packages we need to include.

cc: @bstinsonmhk