### PR TITLE
Add python3-hatchling

### DIFF
--- a/configs/sst_cs_apps-unwanted-python3.yaml
+++ b/configs/sst_cs_apps-unwanted-python3.yaml
@@ -25,6 +25,7 @@ data:
   # Python Maint prefers the standard library venv module
   - python3-virtualenv
   # tox depends on virtualenv, and generally isn't something we want to support in RHEL
+  - python3-hatchling
   - python3-tox
   - tox
 


### PR DESCRIPTION
This is a new dependency of python3-tox, which is required by micropipenv.