### PR TITLE
Update ELN Extras workload for Meta

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -7,18 +7,24 @@ data:
 
   packages:
   - atop
+  - btrfs-progs
   - ccache
   - dbench
-  - dcrpm
   - drgn
+  - duo_unix
+  - duo_unix-selinux
   - et
   - htop
   - fping
+  - libbtrfs
+  - libbtrfsutil
   - libkdumpfile-devel
   - mosh
   - neovim
   - netconsd
   - ngrep
+  - pam_duo
+  - python3-btrfsutil
   - python3-pystemd
   - python3-testslide
   - screen


### PR DESCRIPTION
- Drop dcrpm for the time being
- Add binary packages for duo_unix
- Add binary packages for btrfs-progs