### PR TITLE
Drop GNOME Screenshot from ELN/RHEL 10

### DIFF
--- a/configs/sst_desktop-gnome-screenshot.yaml
+++ b/configs/sst_desktop-gnome-screenshot.yaml
@@ -9,5 +9,4 @@ data:
   - gnome-screenshot
 
   labels:
-  - eln
   - c9s

--- a/configs/sst_desktop-unwanted-eln.yaml
+++ b/configs/sst_desktop-unwanted-eln.yaml
@@ -89,5 +89,8 @@ data:
   # https://fedoraproject.org/wiki/Changes/libsoup_3:_Part_One
   # https://fedoraproject.org/wiki/Changes/libsoup_3:_Part_Two
   - libsoup
+  # The functionality was moved into GNOME Shell itself
+  # https://pagure.io/fedora-workstation/issue/277
+  - gnome-screenshot
   labels:
   - eln


### PR DESCRIPTION
The functionality was moved to GNOME Shell. See:

https://pagure.io/fedora-workstation/issue/277
https://issues.redhat.com/browse/DESKTOP-673