### PR TITLE
Add systemd-networkd and iptables-legacy to ELN Extras workload for Hyperscale

### DIFF
--- a/configs/eln_extras_hyperscale.yaml
+++ b/configs/eln_extras_hyperscale.yaml
@@ -9,7 +9,12 @@ data:
   - btrfs-fuse
   - centos-packager
   - fsverity-utils
+  - iptables-legacy
+  - iptables-legacy-devel
+  - iptables-legacy-libs
+  - iptables-services
   - mock-centos-sig-configs
+  - systemd-networkd
 
   labels:
   - eln-extras


### PR DESCRIPTION
These are unshipped subpackages, but they _are_ build, so it should be possible to add them to ELN Extras this way.