### PR TITLE
st_kernel_maintainers-kernel-base: add kernel-uki-virt and kernel-modules-core

### DIFF
--- a/configs/sst_kernel_maintainers-kernel-base.yaml
+++ b/configs/sst_kernel_maintainers-kernel-base.yaml
@@ -26,8 +26,10 @@ data:
         - kernel-doc
         - kernel-headers
         - kernel-modules
+        - kernel-modules-core
         - kernel-modules-extra
         - kernel-tools
+        - kernel-uki-virt
         - libertas-sd8787-firmware
         - linux-firmware
         - linux-firmware-whence


### PR DESCRIPTION
This request complements the followin MRs:
https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-9/-/merge_requests/1736  
https://gitlab.com/cki-project/kernel-ark/-/merge_requests/2175  

'kernel-core' package is split into 'kernel-core' and 'kernel-core-modules' and 'kernel-uki-virt' sub-package is introduced.

Signed-off-by: Vitaly Kuznetsov <vkuznets@redhat.com>