### PR TITLE
Mark geocode-glib(-devel) as unwanted

### DIFF
--- a/configs/sst_desktop-unwanted-eln.yaml
+++ b/configs/sst_desktop-unwanted-eln.yaml
@@ -92,5 +92,8 @@ data:
   # The functionality was moved into GNOME Shell itself
   # https://pagure.io/fedora-workstation/issue/277
   - gnome-screenshot
+  # Obsoleted by geocode-glib2 that is using libsoup3
+  - geocode-glib
+  - geocode-glib-devel
   labels:
   - eln


### PR DESCRIPTION
Obsoleted by geocode-glib2(-devel) that is using libsoup3, instead of
the already unwanted libsoup2.