### PR TITLE
There will be no modules in the initial RHEL 10.0

### DIFF
--- a/configs/sst_cs_infra_services-varnish-eln.yaml
+++ b/configs/sst_cs_infra_services-varnish-eln.yaml
@@ -11,8 +11,5 @@ data:
   - varnish-docs
   - varnish-devel
 
-  modules_enable:
-  - varnish:6.0
-  
   labels:
   - eln


### PR DESCRIPTION
Removing module dependency so this workload can be properly resolved.