### PR TITLE
There will be no modules in the initial RHEL 10.0

### DIFF
--- a/configs/sst_cs_infra_services-subversion-eln.yaml
+++ b/configs/sst_cs_infra_services-subversion-eln.yaml
@@ -5,9 +5,6 @@ data:
   description: Apache Subversion version control
   maintainer: sst_cs_infra_services
 
-  modules_enable:
-  - subversion:1.14
-
   packages:
   - subversion
   - mod_dav_svn


### PR DESCRIPTION
Removing module dependency so this workload can be properly resolved.