### PR TITLE
There will be no modules in the initial RHEL 10.0

### DIFF
--- a/configs/sst_cs_infra_services-nginx-eln.yaml
+++ b/configs/sst_cs_infra_services-nginx-eln.yaml
@@ -8,9 +8,6 @@ data:
   packages:
   - nginx
   - nginx-all-modules
-
-  modules_enable:
-  - nginx:1.18
   
   labels:
   - eln


### PR DESCRIPTION
Removing module dependency so this workload can be properly resolved.