### PR TITLE
Add lprint and ipp-usb to ELN and C10S

### DIFF
--- a/configs/sst_cs_infra_services-printing-stack-c10s.yaml
+++ b/configs/sst_cs_infra_services-printing-stack-c10s.yaml
@@ -1,0 +1,15 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Printing Stack - Printer Applications
+  description: Suite of software needed for older printers on Linux
+  maintainer: sst_cs_infra_services
+
+  packages:
+  - ipp-usb
+  - lprint
+
+
+  labels:
+  - eln
+  - c10s


### PR DESCRIPTION
lprint provides support for common label printers, which don't support any driverless standards.

ipp-usb enables driverless printing for USB printers, which have support for IPP-over-USB protocol.