### PR TITLE
Automotive-environment: Add the ostree-compliance-mode package

### DIFF
--- a/configs/automotive-environment.yaml
+++ b/configs/automotive-environment.yaml
@@ -55,6 +55,7 @@ data:
     - openssl-libs
     - opus
     - ostree
+    - ostree-compliance-mode
     - passwd
     - podman
     - procps-ng


### PR DESCRIPTION
Hi, 
Opening this PR for the ostree-compliance-mode package. I've added to the automotive-environment.yaml file, but please let me know if it's better suited to automotive-workload-off.
Thank you,
Ian Mullins