### PR TITLE
sst_cockpit-web-console: Add cockpit-ostree

### DIFF
--- a/configs/sst_cockpit-web-console.yaml
+++ b/configs/sst_cockpit-web-console.yaml
@@ -16,6 +16,8 @@ data:
     - cockpit-storaged
     - cockpit-pcp
     - cockpit-doc
+    # RHEL 4 Edge image management
+    - cockpit-ostree
 
   arch_packages:
     aarch64:


### PR DESCRIPTION
We introduce this into ELN (RHEL 10) now, and soon into RHEL 9.

---

Is that kosher like that, or will that break RHEL 9 builds? We haven't done any bureaucracy around RHEL 9 inclusion yet, nor is the current package version ready for it. Do we need to split this into a new file with only a "eln" tag?