### PR TITLE
Add python3-tomli to c9s

### DIFF
--- a/configs/sst_cs_apps-python-data-formats-c9s.yaml
+++ b/configs/sst_cs_apps-python-data-formats-c9s.yaml
@@ -9,6 +9,7 @@ data:
   - python3-lxml
   - python3-pyyaml
   - python3-toml
+  - python3-tomli
 
   labels:
   - c9s


### PR DESCRIPTION
See https://bugzilla.redhat.com/2175213

This is explicitly needed for EL < 10 only, EL 10+ has tomllib in the Python 3.11+ standard library.