### PR TITLE
Split out gtk2 input methods

### DIFF
--- a/configs/sst_i18n-input-methods-gtk2.yaml
+++ b/configs/sst_i18n-input-methods-gtk2.yaml
@@ -1,0 +1,12 @@
+---
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: IBus GTK2 input methods
+  description: Archive GTK2 i18n metapackages.
+  maintainer: sst_i18n
+  labels:
+  - c9s
+  packages:
+  - gtk2-immodule-xim
+  - ibus-gtk2

--- a/configs/sst_i18n-input-methods.yaml
+++ b/configs/sst_i18n-input-methods.yaml
@@ -10,7 +10,6 @@ data:
   - eln
   - c9s
   packages:
-  - gtk2-immodule-xim
   - gtk3-immodule-xim
   - ibus
   - ibus-anthy
@@ -31,6 +30,5 @@ data:
   - ibus-table-chinese-wu
   - ibus-table-chinese-yong
   - ibus-typing-booster
-  - ibus-gtk2
   - ibus-gtk3
   - ibus-wayland


### PR DESCRIPTION
gtk2 is unwanted in RHEL 10.