### PR TITLE
Add in man-pages to the extras

### DIFF
--- a/configs/automotive-workload-off.yaml
+++ b/configs/automotive-workload-off.yaml
@@ -70,6 +70,8 @@ data:
     - libzstd-devel
     - m4
     - make
+    - man-db
+    - man-pages
     - memstrack
     - mtools
     - nano


### PR DESCRIPTION
Developer images need the man-pages and other tools to help developers have better understanding of supported APIs.