### PR TITLE
Remove automotive-sig from automotive-repositories

### DIFF
--- a/configs/automotive-environment.yaml
+++ b/configs/automotive-environment.yaml
@@ -20,7 +20,6 @@ data:
   # in-vehicle set without duplicating the base required minimum.  It
   # doesn't mean their reference images need to be ostree-based.
   packages:
-    - aboot-deploy
     - audit
     - boost
     - bzip2
@@ -39,7 +38,6 @@ data:
     - jose
     - jq
     - kernel-automotive
-    - linux-firmware-automotive
     - libcurl
     - libgpiod
     - libi2c
@@ -56,7 +54,6 @@ data:
     - openssl-libs
     - opus
     - ostree
-    - ostree-compliance-mode
     - passwd
     - podman
     - procps-ng

--- a/configs/automotive-repositories-c9s.yaml
+++ b/configs/automotive-repositories-c9s.yaml
@@ -14,9 +14,6 @@ data:
       cbs-autosd:
         baseurl: https://buildlogs.centos.org/9-stream/autosd/$basearch/packages-main/
         priority: 0
-      cbs-automotive:
-        baseurl: https://buildlogs.centos.org/9-stream/automotive/$basearch/packages-main/
-        priority: 50
       stream-baseos:
         baseurl: https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/$basearch/os/
         priority: 100


### PR DESCRIPTION
The AutoSD project is using the content-resolver output to define the product definition (contents) of the AutoSD repositories (aka product-build). This commit strips the automotive-sig repositories and packages from the content-resolver workload/repositories because they're not considered part of the AutoSD product and are dirtying the product definition (and muddying the line between automotive-sig and AutoSD).

This is needed to create a cleaner divide between the AutoSD project and the automotive-sig project. Later if these packages are needed in AutoSD, they need to be properly promoted to the autosd tag in order to add them here.