### PR TITLE
gdb-minimal is unwanted only on i686

### DIFF
--- a/configs/sst_platform_tools-debuggers-unwanted.yaml
+++ b/configs/sst_platform_tools-debuggers-unwanted.yaml
@@ -7,7 +7,6 @@ data:
 
   unwanted_packages:
   - babeltrace
-  - gdb-minimal
 
   unwanted_arch_packages:
     i686:


### PR DESCRIPTION
commit d90e73f943b04d62221e6af5c0bf2a541f86f4c8 added gdb-minimal for the primary architectures but leaving it unwanted on i686.  However, the general unwanted declaration was not removed, seemingly mistakenly.
