### PR TITLE
automotive-environment: add linux-firmware

### DIFF
--- a/configs/automotive-environment.yaml
+++ b/configs/automotive-environment.yaml
@@ -38,6 +38,7 @@ data:
     - jose
     - jq
     - kernel-automotive
+    - linux-firmware
     - libcurl
     - libgpiod
     - libi2c


### PR DESCRIPTION
The removal of linux-firmware-automotive leaves a gap that needs to be filled. Put linux-firmware in its place.