### PR TITLE
Do not list any gfs2 packages for aarch64

### DIFF
--- a/configs/rhel-8-appstream-comps-performance.yaml
+++ b/configs/rhel-8-appstream-comps-performance.yaml
@@ -45,7 +45,6 @@ data:
   - pcp-pmda-ds389
   - pcp-pmda-ds389log
   - pcp-pmda-elasticsearch
-  - pcp-pmda-gfs2
   - pcp-pmda-gluster
   - pcp-pmda-gpfs
   - pcp-pmda-gpsd
@@ -115,14 +114,17 @@ data:
     ppc64le:
     - pcp-pmda-bcc
     - pcp-pmda-bpftrace
+    - pcp-pmda-gfs2
     - pcp-pmda-infiniband
     - pcp-pmda-perfevent
     s390x:
     - pcp-pmda-bcc
     - pcp-pmda-bpftrace
+    - pcp-pmda-gfs2
     x86_64:
     - pcp-pmda-bcc
     - pcp-pmda-bpftrace
+    - pcp-pmda-gfs2
     - pcp-pmda-infiniband
     - pcp-pmda-mssql
     - pcp-pmda-perfevent

--- a/configs/sst_platform_tools-pcp-grafana.yaml
+++ b/configs/sst_platform_tools-pcp-grafana.yaml
@@ -48,7 +48,6 @@ data:
   - pcp-pmda-ds389
   - pcp-pmda-ds389log
   - pcp-pmda-elasticsearch
-  - pcp-pmda-gfs2
   - pcp-pmda-gluster
   - pcp-pmda-gpfs
   - pcp-pmda-gpsd
@@ -125,16 +124,19 @@ data:
     - pcp-pmda-bcc
     - pcp-pmda-bpf
     - pcp-pmda-bpftrace
+    - pcp-pmda-gfs2
     - pcp-pmda-infiniband
     - pcp-pmda-perfevent
     s390x:
     - pcp-pmda-bcc
     - pcp-pmda-bpf
     - pcp-pmda-bpftrace
+    - pcp-pmda-gfs2
     x86_64:
     - pcp-pmda-bcc
     - pcp-pmda-bpf
     - pcp-pmda-bpftrace
+    - pcp-pmda-gfs2
     - pcp-pmda-infiniband
     - pcp-pmda-mssql
     - pcp-pmda-perfevent

--- a/configs/sst_program-lorax-template-eln.yaml
+++ b/configs/sst_program-lorax-template-eln.yaml
@@ -46,7 +46,6 @@ data:
   - nm-connection-editor
   - librsvg2
   - xfsprogs
-  - gfs2-utils
   - device-mapper-persistent-data
   - xfsdump
   - udisks2
@@ -153,6 +152,7 @@ data:
     - iwl7260-firmware
     - libibverbs
     - rdma-core
+    - gfs2-utils
     ppc64le:
     - powerpc-utils
     - lsvpd
@@ -167,6 +167,7 @@ data:
     - linux-firmware
     - libibverbs
     - rdma-core
+    - gfs2-utils
     aarch64:
     - efibootmgr
     - grub2-efi-aa64-cdboot
@@ -186,6 +187,7 @@ data:
     - s390utils-hmcdrvfs
     - libibverbs
     - rdma-core
+    - gfs2-utils
 
 
   package_placeholders:

--- a/configs/sst_program-lorax-template.yaml
+++ b/configs/sst_program-lorax-template.yaml
@@ -42,7 +42,6 @@ data:
   - nm-connection-editor
   - librsvg2
   - xfsprogs
-  - gfs2-utils
   - device-mapper-persistent-data
   - xfsdump
   - udisks2
@@ -151,6 +150,7 @@ data:
     - iwl7260-firmware
     - libibverbs
     - rdma-core
+    - gfs2-utils
     ppc64le:
     - powerpc-utils
     - lsvpd
@@ -165,6 +165,7 @@ data:
     - linux-firmware
     - libibverbs
     - rdma-core
+    - gfs2-utils
     aarch64:
     - efibootmgr
     - grub2-efi-aa64-cdboot
@@ -184,6 +185,7 @@ data:
     - s390utils-hmcdrvfs
     - libibverbs
     - rdma-core
+    - gfs2-utils
 
 
   package_placeholders:


### PR DESCRIPTION
sst_filesystems-userspace declares these packages unsupported on aarch64 for both C9S and ELN.
