### PR TITLE
Drop Qt 5 from ELN and introduce Qt 6 there

### DIFF
--- a/configs/sst_desktop_applications-qt5.yaml
+++ b/configs/sst_desktop_applications-qt5.yaml
@@ -1,7 +1,7 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: Qt Toolkit
+  name: Qt 5 Toolkit
   description: Software toolkit for developing applications
   maintainer: sst_desktop_applications
 
@@ -71,5 +71,4 @@ data:
   - qt5-qtxmlpatterns-examples
 
   labels:
-  - eln
   - c9s

--- a/configs/sst_desktop_applications-qt6.yaml
+++ b/configs/sst_desktop_applications-qt6.yaml
@@ -1,0 +1,89 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Qt 6 Toolkit
+  description: Software toolkit for developing applications
+  maintainer: sst_desktop_applications
+
+  packages:
+  - python-qt6
+  - qt6-assistant
+  - qt6-designer
+  - qt6-doctools
+  - qt6-linguist
+  - qt6-qdbusviewer
+  - qt6-qt3d
+  - qt6-qt3d-devel
+  - qt6-qt5compat
+  - qt6-qt5compat-devel
+  - qt6-qtbase
+  - qt6-qtbase-common
+  - qt6-qtbase-devel
+  - qt6-qtbase-gui
+  - qt6-qtbase-mysql
+  - qt6-qtbase-odbc
+  - qt6-qtbase-postgresql
+  - qt6-qtbase-private-devel
+  - qt6-qtbase-static
+  - qt6-qtcharts
+  - qt6-qtcharts-devel
+  - qt6-qtconnectivity
+  - qt6-qtconnectivity-devel
+  - qt6-qtdatavis3d
+  - qt6-qtdatavis3d-devel
+  - qt6-qtdeclarative
+  - qt6-qtdeclarative-devel
+  - qt6-qtdeclarative-static
+  - qt6-qtimageformats
+  - qt6-qtimageformats
+  - qt6-qtlottie
+  - qt6-qtlottie-devel
+  - qt6-qtmultimedia
+  - qt6-qtmultimedia-devel
+  - qt6-qtnetworkauth
+  - qt6-qtnetworkauth-devel
+  - qt6-qtpositioning
+  - qt6-qtpositioning-devel
+  - qt6-qtquick3d
+  - qt6-qtquick3d-devel
+  - qt6-qtquicktimeline
+  - qt6-qtquicktimeline-devel
+  - qt6-qtremoteobjects
+  - qt6-qtremoteobjects-devel
+  - qt6-qtscxml
+  - qt6-qtscxml-devel
+  - qt6-qtsensors
+  - qt6-qtsensors-devel
+  - qt6-qtserialbus
+  - qt6-qtserialbus-devel
+  - qt6-qtserialport
+  - qt6-qtserialport-devel
+  - qt6-qtshadertools
+  - qt6-qtshadertools-devel
+  - qt6-qtspeech
+  - qt6-qtspeech-devel
+  - qt6-qtsvg
+  - qt6-qtsvg-devel
+  - qt6-qttools
+  - qt6-qttools-common
+  - qt6-qttools-devel
+  - qt6-qttools-libs-designer
+  - qt6-qttools-libs-designercomponents
+  - qt6-qttools-libs-help
+  - qt6-qttools-static
+  - qt6-qttranslations
+  - qt6-qtvirtualkeyboard
+  - qt6-qtvirtualkeyboard-devel
+  - qt6-qtwayland
+  - qt6-qtwayland-devel
+  - qt6-qtwebchannel
+  - qt6-qtwebchannel-devel
+  - qt6-qtwebsockets
+  - qt6-qtwebsockets-devel
+  - qt6-rpm-macros
+  - qt6-srpm-macros
+  # GNOME integration
+  - adwaita-qt6
+  - qgnomeplatform-qt6
+  labels:
+  - eln

--- a/configs/sst_desktop_applications-unwanted-eln.yaml
+++ b/configs/sst_desktop_applications-unwanted-eln.yaml
@@ -38,12 +38,6 @@ data:
   # Miners are mostly broken and other problems
   # https://bugzilla.redhat.com/show_bug.cgi?id=1913643
   - gnome-online-miners
-  # Only Qt5 will be part of RHEL 9
-  - qt
-  - PyQt4
-  # Don't include web engines that are basically unmaintained
-  - qtwebkit
-  - qt5-qtwebkit
   # As SPICE won't be part of RHEL 9, we will ship Boxes as a Flatpak based on RHEL 8 runtime
   # See https://bugzilla.redhat.com/show_bug.cgi?id=1900581
   - gnome-boxes
@@ -51,7 +45,83 @@ data:
   - ImageMagick
   # Functionality moved into Nautilus, see https://pagure.io/fedora-workstation/issue/167
   - file-roller
-  # Deprecated upstream
+  # Only Qt 6 will be part of RHEL 10
+  # Qt 6
+  # Not needed as we have qgnomeplatform in RHEL
+  - qt6ct
+  - qt6-qtwebengine
+  - qt6-qtwebengine-devtools
+  - qt6-qtwebview
+  # Qt 5
+  - adwaita-qt5
+  - python-qt5
+  - qgnomeplatform-qt5
+  - qt5-doc
+  - qt5-rpm-macros
+  - qt5-srpm-macros
+  - qt5-qt3d
+  - qt5-qt3d-examples
+  - qt5-qtbase
+  - qt5-qtbase-common
+  - qt5-qtbase-examples
+  - qt5-qtbase-gui
+  - qt5-qtbase-mysql
+  - qt5-qtbase-odbc
+  - qt5-qtbase-postgresql
+  - qt5-qtbase-static
   - qt5-qtcanvas3d
+  - qt5-qtconnectivity
+  - qt5-qtconnectivity-examples
+  - qt5-qtdeclarative
+  - qt5-qtdeclarative-examples
+  - qt5-qtdeclarative-static
+  - qt5-qtdoc
+  - qt5-qtgraphicaleffects
+  - qt5-qtimageformats
+  - qt5-qtlocation
+  - qt5-qtlocation-examples
+  - qt5-qtmultimedia
+  - qt5-qtmultimedia-examples
+  - qt5-qtquickcontrols
+  - qt5-qtquickcontrols-examples
+  - qt5-qtquickcontrols2
+  - qt5-qtquickcontrols2-examples
+  - qt5-qtscript
+  - qt5-qtscript-examples
+  - qt5-qtsensors
+  - qt5-qtsensors-examples
+  - qt5-qtserialbus
+  - qt5-qtserialbus-examples
+  - qt5-qtserialport
+  - qt5-qtserialport-examples
+  - qt5-qtsvg
+  - qt5-qtsvg-examples
+  - qt5-assistant
+  - qt5-designer
+  - qt5-doctools
+  - qt5-linguist
+  - qt5-qdbusviewer
+  - qt5-qttools
+  - qt5-qttools-common
+  - qt5-qttools-examples
+  - qt5-qttools-libs-designer
+  - qt5-qttools-libs-designercomponents
+  - qt5-qttools-libs-help
+  - qt5-qttools-static
+  - qt5-qttranslations
+  - qt5-qtwayland
+  - qt5-qtwayland-examples
+  - qt5-qtwebkit
+  - qt5-qtwebchannel
+  - qt5-qtwebchannel-examples
+  - qt5-qtwebsockets
+  - qt5-qtwebsockets-examples
+  - qt5-qtx11extras
+  - qt5-qtxmlpatterns
+  - qt5-qtxmlpatterns-examples
+  # Qt 4
+  - qt
+  - PyQt4
+  - qtwebkit
   labels:
   - eln


### PR DESCRIPTION
We are only supporting one Qt version per major release of RHEL and as Qt 5 is on the end of its development cycle, we are removing it from RHEL 10 and bringing Qt 6 there which is the current stable Qt release in development that will see more of the Wayland specific features developed there. See https://issues.redhat.com/browse/DESKTOP-734 for internal ticket.