### PR TITLE
Add OpenJDK 21 - https://issues.redhat.com/browse/RHELPLAN-156269

### DIFF
--- a/configs/sst_java-java.yaml
+++ b/configs/sst_java-java.yaml
@@ -25,6 +25,15 @@ data:
   - java-11-openjdk-jmods
   - java-11-openjdk-src
   - java-11-openjdk-static-libs
+  - java-17-openjdk
+  - java-17-openjdk-demo
+  - java-17-openjdk-devel
+  - java-17-openjdk-headless
+  - java-17-openjdk-javadoc
+  - java-17-openjdk-javadoc-zip
+  - java-17-openjdk-jmods
+  - java-17-openjdk-src
+  - java-17-openjdk-static-libs
   - copy-jdk-configs
   # Debug packages should be built but shipped in CRB
   - java-1.8.0-openjdk-slowdebug
@@ -51,14 +60,28 @@ data:
   - java-11-openjdk-jmods-fastdebug
   - java-11-openjdk-src-fastdebug
   - java-11-openjdk-static-libs-fastdebug
+  - java-17-openjdk-slowdebug
+  - java-17-openjdk-demo-slowdebug
+  - java-17-openjdk-devel-slowdebug
+  - java-17-openjdk-headless-slowdebug
+  - java-17-openjdk-jmods-slowdebug
+  - java-17-openjdk-src-slowdebug
+  - java-17-openjdk-static-libs-slowdebug
+  - java-17-openjdk-fastdebug
+  - java-17-openjdk-demo-fastdebug
+  - java-17-openjdk-devel-fastdebug
+  - java-17-openjdk-headless-fastdebug
+  - java-17-openjdk-jmods-fastdebug
+  - java-17-openjdk-src-fastdebug
+  - java-17-openjdk-static-libs-fastdebug
   # Core tool for JDK support work
   - byteman
   - byteman-bmunit
   - byteman-javadoc
 
   package_placeholders:
-    java-17-openjdk:
-      srpm: java-17-openjdk
+    java-21-openjdk:
+      srpm: java-21-openjdk
       description: Future long-term supported release of OpenJDK
       requires:
         - fontconfig
@@ -76,17 +99,15 @@ data:
         - cups-devel
         - desktop-file-utils
         - elfutils-devel
+        - file
         - fontconfig-devel
-        - giflib-devel
         - gcc-c++
         - gdb
-        - lcms2-devel
-        - libpng-devel
-        - libjpeg-devel
         - libX11-devel
         - libXi-devel
         - libXinerama-devel
         - libXrandr-devel
+        - libXrender-devel
         - libXt-devel
         - libXtst-devel
         - libxslt
@@ -94,8 +115,12 @@ data:
         - pkgconfig
         - xorg-x11-proto-devel
         - zip
+        - tar
+        - unzip
         - javapackages-filesystem
         - libffi-devel
         - tzdata-java
+        - ca-certificates
         - gcc
         - systemtap-sdt-devel
+        - make


### PR DESCRIPTION
* Move `java-17-openjdk` to packages now it exists in both Fedora & RHEL

We've started the PRP process to add `java-21-openjdk` to RHEL 8 & 9 for the next release in November. OpenJDK 21 is expected to be the next long term support release of OpenJDK and is due for release in September.

This also updates `java-17-openjdk` to be listed with `java-1.8.0-openjdk` and `java-11-openjdk`. When this file was originally added, it was only a placeholder in RHEL 9, but it is now a regular package in Fedora and RHEL 8 & 9.