### PR TITLE
Update the accessibility workload

### DIFF
--- a/configs/sst_desktop-accessibility-eln.yaml
+++ b/configs/sst_desktop-accessibility-eln.yaml
@@ -6,11 +6,10 @@ data:
   maintainer: sst_desktop
 
   packages:
-  - orca
-  - festival
-  - speech-dispatcher
-  - at-spi2-atk
   - at-spi2-core
+  - liblouis
+  - orca
+  - speech-dispatcher
 
   labels:
   - eln

--- a/configs/sst_desktop-unwanted-eln.yaml
+++ b/configs/sst_desktop-unwanted-eln.yaml
@@ -95,5 +95,8 @@ data:
   # Obsoleted by geocode-glib2 that is using libsoup3
   - geocode-glib
   - geocode-glib-devel
+  # Only espeak-ng is the supported speech synthetizer in RHEL 10
+  - festival
+  - flite
   labels:
   - eln


### PR DESCRIPTION
Together with people from the Red Hat's Linux accessibility group, we've agreed on only shipping the espeak-ng speech synthetizer (owned by sst_cs_infra_services) in RHEL 10 and drop flite and festival - both are no longer maintained upstream for some time and they do have their set of problems. espeak-ng is actively maintained upstream and has a brighter future in RHEL 10. The only downside of this plan is that espeak-ng sounds "robotic" in opposed to festival that is using the natural voice. If there will be demands in the future for the natural voice synthetizer, then we might look into how RHVoice is doing (currently not even in Fedora). See https://issues.redhat.com/browse/DESKTOP-660 for the internal discussion.

Drop at-spi2-atk as it has been merged into at-spi2-core.

Explicitly add liblouis which is a braille translator.