### PR TITLE
Replace Gedit with GNOME Text Editor

### DIFF
--- a/configs/sst_desktop-gnome-text-editor.yaml
+++ b/configs/sst_desktop-gnome-text-editor.yaml
@@ -1,13 +1,12 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: Gedit
+  name: GNOME Text Editor
   description: Text editor for Workstation
   maintainer: sst_desktop
 
   packages:
-  - gedit
-  - gedit-plugins
+  - gnome-text-editor
 
   labels:
   - c9s


### PR DESCRIPTION
Follow what we've done in Fedora Workstation as well, see https://issues.redhat.com/browse/DESKTOP-737 and
https://pagure.io/fedora-workstation/issue/248