### PR TITLE
Rust: replace rls with rust-analyzer

### DIFF
--- a/configs/sst_platform_tools-rust-toolset.yaml
+++ b/configs/sst_platform_tools-rust-toolset.yaml
@@ -9,8 +9,7 @@ data:
   - rust
   - cargo
   - clippy
-  - rls
-  - rust-analysis
+  - rust-analyzer
   - rust-doc
   - rust-std-static
   - rustfmt


### PR DESCRIPTION
The new `rust-analyzer` has replaced `rls` and its supporting files in `rust-analysis`.