### PR TITLE
Rely on unwanted_source_packages when specifying unwanted Qt 5 packages

### DIFF
--- a/configs/sst_desktop_applications-unwanted-eln.yaml
+++ b/configs/sst_desktop_applications-unwanted-eln.yaml
@@ -54,74 +54,42 @@ data:
   - qt6-qtwebview
   # Qt 5
   - adwaita-qt5
-  - python-qt5
   - qgnomeplatform-qt5
-  - qt5-doc
-  - qt5-rpm-macros
-  - qt5-srpm-macros
-  - qt5-qt3d
-  - qt5-qt3d-examples
-  - qt5-qtbase
-  - qt5-qtbase-common
-  - qt5-qtbase-examples
-  - qt5-qtbase-gui
-  - qt5-qtbase-mysql
-  - qt5-qtbase-odbc
-  - qt5-qtbase-postgresql
-  - qt5-qtbase-static
-  - qt5-qtcanvas3d
-  - qt5-qtconnectivity
-  - qt5-qtconnectivity-examples
-  - qt5-qtdeclarative
-  - qt5-qtdeclarative-examples
-  - qt5-qtdeclarative-static
-  - qt5-qtdoc
-  - qt5-qtgraphicaleffects
-  - qt5-qtimageformats
-  - qt5-qtlocation
-  - qt5-qtlocation-examples
-  - qt5-qtmultimedia
-  - qt5-qtmultimedia-examples
-  - qt5-qtquickcontrols
-  - qt5-qtquickcontrols-examples
-  - qt5-qtquickcontrols2
-  - qt5-qtquickcontrols2-examples
-  - qt5-qtscript
-  - qt5-qtscript-examples
-  - qt5-qtsensors
-  - qt5-qtsensors-examples
-  - qt5-qtserialbus
-  - qt5-qtserialbus-examples
-  - qt5-qtserialport
-  - qt5-qtserialport-examples
-  - qt5-qtsvg
-  - qt5-qtsvg-examples
-  - qt5-assistant
-  - qt5-designer
-  - qt5-doctools
-  - qt5-linguist
-  - qt5-qdbusviewer
-  - qt5-qttools
-  - qt5-qttools-common
-  - qt5-qttools-examples
-  - qt5-qttools-libs-designer
-  - qt5-qttools-libs-designercomponents
-  - qt5-qttools-libs-help
-  - qt5-qttools-static
-  - qt5-qttranslations
-  - qt5-qtwayland
-  - qt5-qtwayland-examples
-  - qt5-qtwebkit
-  - qt5-qtwebchannel
-  - qt5-qtwebchannel-examples
-  - qt5-qtwebsockets
-  - qt5-qtwebsockets-examples
-  - qt5-qtx11extras
-  - qt5-qtxmlpatterns
-  - qt5-qtxmlpatterns-examples
   # Qt 4
   - qt
   - PyQt4
   - qtwebkit
+  unwanted_source_packages:
+  # Qt 5
+  - python-qt5
+  - qt5
+  - qt5-doc
+  - qt5-qt3d
+  - qt5-qt3d
+  - qt5-qtbase
+  - qt5-qtcanvas3d
+  - qt5-qtconnectivity
+  - qt5-qtdeclarative
+  - qt5-qtdoc
+  - qt5-qtgraphicaleffects
+  - qt5-qtimageformats
+  - qt5-qtlocation
+  - qt5-qtmultimedia
+  - qt5-qtquickcontrols
+  - qt5-qtquickcontrols2
+  - qt5-qtscript
+  - qt5-qtsensors
+  - qt5-qtserialbus
+  - qt5-qtserialport
+  - qt5-qtsvg
+  - qt5-qttools
+  - qt5-qttranslations
+  - qt5-qtwayland
+  - qt5-qtwebkit
+  - qt5-qtwebchannel
+  - qt5-qtwebsockets
+  - qt5-qtx11extras
+  - qt5-qtxmlpatterns
+
   labels:
   - eln


### PR DESCRIPTION
Triggered by noticing that we've previously marked python-qt5 as unwanted, but this is an SPRM and not the RPM (which is a python3-qt5).