### PR TITLE
Move kpatch from sst_kernel_ft to sst_kernel_security

### DIFF
--- a/configs/sst_kernel_security-kpatch.yaml
+++ b/configs/sst_kernel_security-kpatch.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: kpatch
   description: Dynamic kernel patch manager
-  maintainer: sst_kernel_ft
+  maintainer: sst_kernel_security
 
   packages: []
 


### PR DESCRIPTION
A new Kernel Security SST was formed out of the Kernel FT SST.  Update the kpatch content accordingly.