### PR TITLE
Remove syslinux-perl and netpbm-progs from redhat-logos requirements

### DIFF
--- a/configs/sst_desktop-branding.yaml
+++ b/configs/sst_desktop-branding.yaml
@@ -23,8 +23,6 @@ data:
       requires:
         - coreutils
       buildrequires:
-        - syslinux-perl
-        - netpbm-progs
         - hardlink
     redhat-logos-httpd:
       srpm: redhat-logos


### PR DESCRIPTION
These are not needed anymore, see
https://bugzilla.redhat.com/show_bug.cgi?id=2176558