### PR TITLE
Update sst_platform_tools-misc.yaml removing tbb

### DIFF
--- a/configs/sst_platform_tools-misc.yaml
+++ b/configs/sst_platform_tools-misc.yaml
@@ -11,10 +11,6 @@ data:
   - binutils-gold
   - annobin
   - annobin-annocheck
-  - python3-tbb
-  - tbb
-  - tbb-devel
-  - tbb-doc
 
   labels:
   - eln


### PR DESCRIPTION
Removes the TBB package from the sst_platform_tools-misc collection as it is only needed when developing using certain experimental features of C++-17