### PR TITLE
Fix python-tornado status

### DIFF
--- a/configs/sst_cs_apps-unwanted-python3.yaml
+++ b/configs/sst_cs_apps-unwanted-python3.yaml
@@ -100,7 +100,6 @@ data:
   - python3-html5lib
 
   # Web servers usually used for %check only, have a huge dep chain
-  - python3-tornado
   - python3-twisted
 
   # We only support two basic Sphinx themes in RHEL (alabaster and RTD)
@@ -159,7 +158,6 @@ data:
   - python-freezegun
   - python-trustme
   - python-html5lib
-  - python-tornado
   - python-twisted
   - python-Pallets-Sphinx-Themes
   - python-sphinx-theme-py3doc-enhanced


### PR DESCRIPTION
python-tornado was re-added to RHEL 9 post-GA for the Keylime workload.
