### PR TITLE
Update sst_platform_tools-rust-toolset.yaml

### DIFF
--- a/configs/sst_platform_tools-rust-toolset.yaml
+++ b/configs/sst_platform_tools-rust-toolset.yaml
@@ -14,16 +14,8 @@ data:
   - rust-std-static
   - rustfmt
   - rust-srpm-macros
+  - rust-toolset
 
   labels:
   - eln
   - c9s
-
-  package_placeholders:
-    rust-toolset:
-      srpm: rust-toolset
-      description: Meta-package for rust-toolset
-      requires:
-        - rust
-        - cargo
-      buildrequires: []


### PR DESCRIPTION
We don't need a placeholder for `rust-toolset` anymore, as that's now a (%rhel-conditional) subpackage of the rust srpm.