### PR TITLE
Update Qt6 workloads in ELN

### DIFF
--- a/configs/eln_extras_qt6.yaml
+++ b/configs/eln_extras_qt6.yaml
@@ -6,47 +6,23 @@ data:
   maintainer: tdawson
 
   packages:
-  - qt6-rpm-macros
-  - qt6-srpm-macros
-  - qt6-qt3d
-  - qt6-qt5compat
-  - qt6-qtbase
-  - qt6-qtcharts
-  - qt6-qtconnectivity
-  - qt6-qtdatavis3d
-  - qt6-qtdeclarative
-  - qt6-qtimageformats
-  - qt6-qtlottie
-  - qt6-qtmultimedia
-  - qt6-qtnetworkauth
-  - qt6-qtpositioning
-  - qt6-qtquick3d
-  - qt6-qtquicktimeline
-  - qt6-qtremoteobjects
-  - qt6-qtscxml
-  - qt6-qtsensors
-  - qt6-qtserialbus
-  - qt6-qtserialport
-  - qt6-qtshadertools
-  - qt6-qtsvg
-  - qt6-qttools
-  - qt6-qttranslations
-  - qt6-qtvirtualkeyboard
-  - qt6-qtwayland
-  - qt6-qtwebchannel
-  - qt6-qtwebsockets
+  - python3-pyqt6-charts
 
   labels:
   - eln-extras
 
   arch_packages:
     aarch64:
+    - python3-pyqt6-webengine
     - qt6ct
     - qt6-qtwebengine
     - qt6-qtwebengine-devtools
+    - qt6-qtwebview
     ppc64le:
     - qt6ct
     x86_64:
+    - python3-pyqt6-webengine
     - qt6ct
     - qt6-qtwebengine
     - qt6-qtwebengine-devtools
+    - qt6-qtwebview

--- a/configs/sst_desktop_applications-qt6.yaml
+++ b/configs/sst_desktop_applications-qt6.yaml
@@ -36,7 +36,10 @@ data:
   - qt6-qtdeclarative-devel
   - qt6-qtdeclarative-static
   - qt6-qtimageformats
-  - qt6-qtimageformats
+  - qt6-qtlanguageserver
+  - qt6-qtlanguageserver-devel
+  - qt6-qtlocation
+  - qt6-qtlocation-devel
   - qt6-qtlottie
   - qt6-qtlottie-devel
   - qt6-qtmultimedia


### PR DESCRIPTION
Add new Qt6 components in 6.5.1, and limit the Qt6 ELN Extras workload to packages not in ELN proper.

/cc @tdawson @tpopela 