### PR TITLE
Unplacehold nispor

### DIFF
--- a/configs/sst_networking-management-server.yaml
+++ b/configs/sst_networking-management-server.yaml
@@ -49,14 +49,8 @@ data:
   - NetworkManager-dispatcher-routing-rules
   - NetworkManager-cloud-setup
   - nmstate
-
-  package_placeholders:
-    python3-nispor:
-      description: Needed by nmstate. RHEL build bundles rust, Fedora build cannot.
-      srpm: nispor
-    nispor:
-      description: Needed by nmstate. RHEL build bundles rust, Fedora build cannot.
-      srpm: nispor
+  - nispor
+  - python3-nispor
 
   unwanted_packages:
   # On RHEL-8, jimtcl was a dependency of usb_modeswitch. Since usb_modeswitch 2.6.0, the


### PR DESCRIPTION
Rawhide now contains the changes needed to use vendored dependencies in ELN builds of nispor, so there is no further reason to placehold it.
