### PR TITLE
Update caladea-fonts package name for ELN

### DIFF
--- a/configs/sst_i18n-fonts-eln.yaml
+++ b/configs/sst_i18n-fonts-eln.yaml
@@ -14,12 +14,12 @@ data:
   - dejavu-sans-mono-fonts
   - dejavu-serif-fonts
   - google-carlito-fonts
+  - google-crosextra-caladea-fonts
   - google-noto-emoji-color-fonts
   - google-noto-sans-cjk-ttc-fonts
   - google-noto-sans-gurmukhi-fonts
   - google-noto-sans-sinhala-vf-fonts
   - google-roboto-slab-fonts
-  - ht-caladea-fonts
   - jomolhari-fonts
   - julietaula-montserrat-fonts
   - khmer-os-system-fonts


### PR DESCRIPTION
ht-caladea-fonts was retired in F38+.
