### PR TITLE
maven-mapping is no longer unwanted by sst_cs_apps

### DIFF
--- a/configs/sst_cs_apps-unwanted-java.yaml
+++ b/configs/sst_cs_apps-unwanted-java.yaml
@@ -47,7 +47,6 @@ data:
   - maven-invoker
   - maven-invoker-plugin
   - maven-javadoc-plugin
-  - maven-mapping
   - maven-reporting-api
   - maven-reporting-impl
   - maven-script-interpreter


### PR DESCRIPTION
maven-mapping is a build-dependency of bnd-maven-plugin, which is needed in RHEL 10
https://src.fedoraproject.org/rpms/aqute-bnd/pull-request/19