### PR TITLE
Remove libdb from supported packages

### DIFF
--- a/configs/sst_cs_apps-embedded.yaml
+++ b/configs/sst_cs_apps-embedded.yaml
@@ -7,7 +7,6 @@ data:
 
   packages:
   - gdbm-devel
-  - libdb-devel
   - sqlite-devel
   - sqlite
 

--- a/configs/sst_cs_apps-unwanted.yaml
+++ b/configs/sst_cs_apps-unwanted.yaml
@@ -9,6 +9,8 @@ data:
   - js-uglify
   - web-assets-devel
   - mercurial                       # Hard to maintain while not the most popular choice anymore.
+  - libdb-devel                     # Deprecated in RHEL9
+  - libdb
 
   labels:
   - eln


### PR DESCRIPTION
SInce libdb is deprecated and probably will be unwanted, so we should highlight it.
@hhorak PTAL 