### PR TITLE
Split tbb listings for c9s and eln

### DIFF
--- a/configs/sst_platform_tools-misc.yaml
+++ b/configs/sst_platform_tools-misc.yaml
@@ -1,7 +1,7 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: binutils/annobin/tbb
+  name: binutils/annobin
   description: Set of packages that GCC depends on
   maintainer: sst_platform_tools
 
@@ -11,10 +11,6 @@ data:
   - binutils-gold
   - annobin
   - annobin-annocheck
-  - python3-tbb
-  - tbb
-  - tbb-devel
-  - tbb-doc
 
   labels:
   - eln

--- a/configs/sst_platform_tools-tbb-exclusion.yaml
+++ b/configs/sst_platform_tools-tbb-exclusion.yaml
@@ -2,7 +2,7 @@ document: feedback-pipeline-unwanted
 version: 1
 data:
   name: SST Platform Tools Misc Exclusion List  
-  description: Packages from the sst_platform_tools-misc.yaml file that are not needed for ELN
+  description: Packages from the sst_platform_tools-tbb.yaml file that are not needed for ELN
   maintainer: sst_platform_tools
 
   unwanted_packages:

--- a/configs/sst_platform_tools-tbb.yaml
+++ b/configs/sst_platform_tools-tbb.yaml
@@ -1,0 +1,15 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: tbb
+  description: Threading Building Blocks library
+  maintainer: sst_platform_tools
+
+  packages:
+  - python3-tbb
+  - tbb
+  - tbb-devel
+  - tbb-doc
+
+  labels:
+  - c9s


### PR DESCRIPTION
tbb is currently listed as both required and unwanted in ELN as a result of #822.  This avoids that by splitting tbb out into its own c9s-only workload.

Note that dyninst still requires tbb, so further work is required to actually drop tbb from ELN.

/cc @nickclifton
