### PR TITLE
Remove pmem libraries

### DIFF
--- a/configs/sst_storage_io-packages-unwanted.yaml
+++ b/configs/sst_storage_io-packages-unwanted.yaml
@@ -9,6 +9,11 @@ data:
   - libhbaapi
   - libhbalinux
 
+  unwanted_source_packages:
+  - nvml
+  - libpmemobj-cpp
+  - pmdk-convert
+
   labels:
   - eln
   - c9s


### PR DESCRIPTION
Intel is dropping support for these libraries.  It's not clear whether other maintainers will step up to develop/maintain them.