### PR TITLE
Changes regarding c10s/c9s printing stack

### DIFF
--- a/configs/sst_cs_infra_services-development-packages.yaml
+++ b/configs/sst_cs_infra_services-development-packages.yaml
@@ -40,6 +40,9 @@ data:
   - ppp-devel
   # python-cups
   - python-cups-doc
+  # qpdf
+  - qpdf
+  - qpdf-devel
   # sendmail
   - sendmail-milter-devel
   # tcl

--- a/configs/sst_cs_infra_services-printing-stack-c10s.yaml
+++ b/configs/sst_cs_infra_services-printing-stack-c10s.yaml
@@ -6,8 +6,12 @@ data:
   maintainer: sst_cs_infra_services
 
   packages:
+  - cups-browsed
   - ipp-usb
+  - libcupsfilters
+  - libppd
   - lprint
+  - pappl
 
 
   labels:

--- a/configs/sst_cs_infra_services-unwanted-c10s.yaml
+++ b/configs/sst_cs_infra_services-unwanted-c10s.yaml
@@ -6,6 +6,8 @@ data:
   maintainer: sst_cs_infra_services
 
   unwanted_packages:
+  # ghostscript
+  - ghostscript-x11
   # gutenprint
   - gutenprint-libs-ui
 


### PR DESCRIPTION
ghostscript-x11 no longer in c10s
qpdf and qpdf-devel are in CRB in c9s+ now
add new packages from cups-filters 2.0 generation