### PR TITLE
Add deprecated Perl modules for IPv6

### DIFF
--- a/configs/unwanted-eln-packages.yaml
+++ b/configs/unwanted-eln-packages.yaml
@@ -63,3 +63,8 @@ data:
   #Jaroslav Kysela:
   # It's sound font loader for (really) old Creative hardware. The recent hardware does not require it.
   - fxload
+  
+  # Michal Josef Špaček
+  # Obsolete Perl modules, which were replaced by proper ipv6 functionality
+  - perl-IO-Socket-INET6
+  - perl-Socket6


### PR DESCRIPTION
IPv6 support is in standard libraries (perl-Socket, perl-IO-Socket-IP) and we are in process of removing this depdencies.