### PR TITLE
More RHEL 10 desktop removals

### DIFF
--- a/configs/sst_desktop-unwanted-eln.yaml
+++ b/configs/sst_desktop-unwanted-eln.yaml
@@ -98,5 +98,7 @@ data:
   # Only espeak-ng is the supported speech synthetizer in RHEL 10
   - festival
   - flite
+  # Deprecated from 2010 - https://dbus.freedesktop.org/doc/dbus-glib/
+  - dbus-glib
   labels:
   - eln

--- a/configs/sst_desktop_applications-evolution-eln.yaml
+++ b/configs/sst_desktop_applications-evolution-eln.yaml
@@ -15,8 +15,6 @@ data:
   - evolution-ews-langpacks
   - evolution-help
   - evolution-langpacks
-  - evolution-mapi
-  - evolution-mapi-langpacks
   - evolution-pst
   - evolution-spamassassin
 

--- a/configs/sst_desktop_applications-gnome-photos.yaml
+++ b/configs/sst_desktop_applications-gnome-photos.yaml
@@ -11,5 +11,4 @@ data:
   - exiv2
 
   labels:
-  - eln
   - c9s

--- a/configs/sst_desktop_applications-inkscape.yaml
+++ b/configs/sst_desktop_applications-inkscape.yaml
@@ -10,5 +10,4 @@ data:
   - inkscape-view
 
   labels:
-  - eln
   - c9s

--- a/configs/sst_desktop_applications-unwanted-eln.yaml
+++ b/configs/sst_desktop_applications-unwanted-eln.yaml
@@ -93,6 +93,8 @@ data:
   # Not ported to libsoup3, not maintained upstream and in the end no need for
   # accessing Google Drive (why not other similar solutions?) in Nautilus
   - libgdata
+  # Replaced by enchant2 and applications should be ported to it
+  - enchant
 
   labels:
   - eln

--- a/configs/sst_desktop_applications-unwanted-eln.yaml
+++ b/configs/sst_desktop_applications-unwanted-eln.yaml
@@ -90,6 +90,9 @@ data:
   - qt5-qtwebsockets
   - qt5-qtx11extras
   - qt5-qtxmlpatterns
+  # Not ported to libsoup3, not maintained upstream and in the end no need for
+  # accessing Google Drive (why not other similar solutions?) in Nautilus
+  - libgdata
 
   labels:
   - eln


### PR DESCRIPTION
Drop evolution-mapi, gnome-photos, inkscape, libgdata and mark enchant, dbus-glib as unwanted.