### PR TITLE
sst_kernel_rts-kernel-rt: add kernel-rt-{,debug-}modules-core

### DIFF
--- a/configs/sst_kernel_rts-kernel-rt-base.yaml
+++ b/configs/sst_kernel_rts-kernel-rt-base.yaml
@@ -11,6 +11,7 @@ data:
         - kernel-rt
         - kernel-rt-core
         - kernel-rt-modules
+        - kernel-rt-modules-core
         - kernel-rt-modules-extra
         - kernel-rt-kvm
         - tuned-profiles-realtime

--- a/configs/sst_kernel_rts-kernel-rt-develdebug.yaml
+++ b/configs/sst_kernel_rts-kernel-rt-develdebug.yaml
@@ -11,6 +11,7 @@ data:
         - kernel-rt-debug
         - kernel-rt-debug-core
         - kernel-rt-debug-modules
+        - kernel-rt-debug-modules-core
         - kernel-rt-debug-modules-extra
         - kernel-rt-debug-kvm
         - kernel-rt-devel


### PR DESCRIPTION
kernel-rt-core has been split into kernel-rt-core and kernel-rt-modules-core.

Reflect the change in the kernel-rt workloads.

Signed-off-by: Juri Lelli <juri.lelli@redhat.com>