### PR TITLE
Update sst_platform_tools-go-toolset.yaml (add go-rpm-macros)

### DIFF
--- a/configs/sst_platform_tools-go-toolset.yaml
+++ b/configs/sst_platform_tools-go-toolset.yaml
@@ -13,6 +13,7 @@ data:
   - golang-src
   - golang-tests
   - go-srpm-macros
+  - go-rpm-macros
 
   arch_packages:
     x86_64:


### PR DESCRIPTION
go-srpm-macros is now a sub package of go-rpm-macros, and packages in the wider distribution depend on both