### PR TITLE
fwupd-efi is only for UEFI architectures

### DIFF
--- a/configs/sst_desktop_firmware_bootloaders-fwupd-eln.yaml
+++ b/configs/sst_desktop_firmware_bootloaders-fwupd-eln.yaml
@@ -7,7 +7,12 @@ data:
 
   packages:
   - fwupd
-  - fwupd-efi
+
+  arch_packages:
+    aarch64:
+    - fwupd-efi
+    x86_64:
+    - fwupd-efi
 
   labels:
   - eln


### PR DESCRIPTION
This should fix the warning in this workload.

/cc @tpopela
