### PR TITLE
Remove pigz

### DIFF
--- a/configs/automotive-workload-off.yaml
+++ b/configs/automotive-workload-off.yaml
@@ -86,7 +86,6 @@ data:
     - perl-Carp
     - perl-devel
     - perl-interpreter
-    - pigz
     - pkgconf
     - polkit
     - python3

--- a/configs/sst_arch_hw.yaml
+++ b/configs/sst_arch_hw.yaml
@@ -26,7 +26,6 @@ data:
   - alsa-utils
   - speexdsp
   - hwloc
-  - pigz
   - ethtool
 
   arch_packages:

--- a/configs/sst_program-lorax-template-eln.yaml
+++ b/configs/sst_program-lorax-template-eln.yaml
@@ -16,7 +16,6 @@ data:
   - dnf
   - rpm-ostree
   - ostree
-  - pigz
   - kernel
   - kernel-modules
   - kernel-modules-extra

--- a/configs/sst_program-lorax-template.yaml
+++ b/configs/sst_program-lorax-template.yaml
@@ -15,7 +15,6 @@ data:
   - dnf
   - rpm-ostree
   - ostree
-  - pigz
   - kernel
   - kernel-modules
   - kernel-modules-extra


### PR DESCRIPTION
pigz was used to compress and decompress gzip'd kernel modules.  It's no longer used AFAICT anywhere in anaconda or for kernel module compression.  It can be dropped as a dependency, which should eventually lead to its removal from RHEL and Fedora.  It is also worth noting that pigz hasn't been updated in YEARS and also points to the packages' lack of use.