### PR TITLE
Add pcre and pcre-devel as unwanted

### DIFF
--- a/configs/sst_cs_apps-apps-unsorted-c9s.yaml
+++ b/configs/sst_cs_apps-apps-unsorted-c9s.yaml
@@ -1,0 +1,23 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Other packages from SST CS Aps for c9s
+  description: Unsorted tools owned by CS Apps SST
+  maintainer: sst_cs_apps
+
+  packages:
+  - less
+  - time
+  - pcre2
+  - pcre2-devel
+  - pcre
+  - pcre-devel
+  - quota
+  - quota-nld
+  - quota-rpc
+  - quota-doc
+  - quota-nls
+  - quota-warnquota
+
+  labels:
+  - c9s

--- a/configs/sst_cs_apps-apps-unsorted-eln.yaml
+++ b/configs/sst_cs_apps-apps-unsorted-eln.yaml
@@ -1,7 +1,7 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: Other packages from SST CS Aps
+  name: Other packages from SST CS Aps for ELN
   description: Unsorted tools owned by CS Apps SST
   maintainer: sst_cs_apps
 
@@ -10,8 +10,6 @@ data:
   - time
   - pcre2
   - pcre2-devel
-  - pcre
-  - pcre-devel
   - quota
   - quota-nld
   - quota-rpc
@@ -21,4 +19,3 @@ data:
 
   labels:
   - eln
-  - c9s

--- a/configs/sst_cs_apps-unwanted-eln.yaml
+++ b/configs/sst_cs_apps-unwanted-eln.yaml
@@ -1,0 +1,14 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Unwanted packages from CS Apps SST
+  description: Packages we do not want to ship for CS Apps SST
+  maintainer: sst_cs_apps
+
+  unwanted_packages:
+    # Pcre is deprecated and unsupported by upstream since Fedora 38
+    - pcre
+    - pcre-devel
+
+  labels:
+  - eln


### PR DESCRIPTION
Pcre project has been deprecated and unsupported by upstream since Fedora 38 Fedora Change: https://fedoraproject.org/wiki/Changes/PcreDeprecation