### PR TITLE
Remove can-utils, libiio

### DIFF
--- a/configs/sst_edge.yaml
+++ b/configs/sst_edge.yaml
@@ -6,7 +6,6 @@ data:
   maintainer: sst_edge
 
   packages:
-  - can-utils
   - libgpiod
   - libgpiod-c++
   - libgpiod-devel
@@ -14,10 +13,6 @@ data:
   - python3-libgpiod
   - libi2cd
   - libi2cd-devel
-  - libiio
-  - libiio-devel
-  - libiio-utils
-  - python3-iio
 
   # Packages co-maintained with the CoreOS SST
   - coreos-installer


### PR DESCRIPTION
At one point these were planned for c9s but were never added.
