### PR TITLE
Explain why nasm and yasm are unwanted

### DIFF
--- a/configs/ssg_platform_tools-unwanted.yaml
+++ b/configs/ssg_platform_tools-unwanted.yaml
@@ -23,6 +23,8 @@ data:
   - dpkg
   - dpkg-devel
   - dselect
+  # nasm and yasm are required by firefox.  If we could remove this
+  # dependency then we could probably drop them entirely.
   - nasm
   - nasm-rdoff
   - yasm


### PR DESCRIPTION
This patch adds a comment to the ssg_platform_tools-unwanted file explaining why the nasm and yasm tools are needed, and why we would like to drop them.