### PR TITLE
bind9-next is unwanted

### DIFF
--- a/configs/sst_program-unwanted.yaml
+++ b/configs/sst_program-unwanted.yaml
@@ -130,6 +130,7 @@ data:
     - redhat-lsb-submod-security
     - reiserfs-utils
     - screen
+    - bind9-next
 
   labels:
   - eln


### PR DESCRIPTION
It's not properly dep-pruned for EL so let's be sure we notice if it shows up again.