### PR TITLE
Remove compat-openssl11

### DIFF
--- a/configs/sst_security_crypto-openssl-c9s.yaml
+++ b/configs/sst_security_crypto-openssl-c9s.yaml
@@ -9,6 +9,7 @@ data:
 
   packages:
     - openssl
+    - compat-openssl11
 
   labels:
-    - eln
+    - c9s


### PR DESCRIPTION
We do not plan on supporting OpenSSL 1.1 in 10, so drop it from the package set. There should be no users of this in the distribution since we did not ship the development package.