### PR TITLE
Add an initial content for most common components used in container images

### DIFF
--- a/configs/sst_cs_apps-containers.yaml
+++ b/configs/sst_cs_apps-containers.yaml
@@ -1,0 +1,47 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Application Streams Container Components
+  description: Components required by RHEL Application Streams container images
+  maintainer: sst_cs_apps
+
+  packages:
+  # common tools used in container scripts and OpenShift tools
+  - bsdtar
+  - bzip2
+  - findutils
+  - gettext-envsubst
+  - git
+  - glibc-langpack-en
+  - groff-base
+  - lsof
+  - make
+  - nss_wrapper-libs
+  - patch
+  - procps-ng
+  - rsync
+  - tar
+  - unzip
+  - wget
+  - which
+
+  # build tools often used for binary extensions
+  - autoconf
+  - automake
+  - gcc-c++
+  - gdb
+  - gd-devel
+  - libcurl-devel
+  - libpq-devel
+  - libxml2-devel
+  - libxslt-devel
+  - mariadb-connector-c-devel
+  - openssl-devel
+  - sqlite-devel
+  - zlib-devel
+
+  # common dependency of app containers in s2i-base
+  - nodejs-npm
+
+  labels:
+  - eln


### PR DESCRIPTION
This list does not include packages installed in some particular images, like the list in https://github.com/sclorg/s2i-python-container/blob/master/3.11/Dockerfile.fedora#L41-L42

I'm not clear whether we need a full list for the purpose of content resolver or whether we can be fine with this initial packages set.

@pkubatrh @phracek WDYT?