### PR TITLE
Mark openssl-pkcs11 as unwanted in ELN

### DIFF
--- a/configs/sst_security_crypto-unwanted-eln.yaml
+++ b/configs/sst_security_crypto-unwanted-eln.yaml
@@ -1,0 +1,13 @@
+---
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  maintainer: sst_security_crypto
+  name: Unwanted security/cryptography packages in ELN
+  description: Unwanted cryptography packages in ELN
+
+  unwanted_packages:
+    # OpenSSL 3 deprecated engines, use the openssl pkcs11 provider instead
+    - openssl-pkcs11
+  labels:
+    - eln


### PR DESCRIPTION
openssl-pkcs11 provides an OpenSSL ENGINE implementation for PKCS#11, but OpenSSL 3.0 has deprecated ENGINEs in favour of using providers. Since we are working on bringing an OpenSSL PKCS#11 Provider into Fedora [\[1\]][1] and want to use that in ELN, mark openssl-pkcs11 as unwanted.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2211754