### PR TITLE
Another round of ELN warning fixes

### DIFF
--- a/configs/sst_cs_plumbers-cli-tools-c9s.yaml
+++ b/configs/sst_cs_plumbers-cli-tools-c9s.yaml
@@ -14,6 +14,7 @@ data:
   - environment-modules
   - gperf
   - iputils
+  - iputils-ninfod
   - traceroute
   - lsof
   - ps_mem
@@ -31,3 +32,4 @@ data:
 
   labels:
   - eln
+  - c9s

--- a/configs/sst_desktop_applications-unwanted-eln.yaml
+++ b/configs/sst_desktop_applications-unwanted-eln.yaml
@@ -7,7 +7,6 @@ data:
   unwanted_packages:
   # RHEL 10 additional unwanted entries:
   - gnome-common
-  - autoconf-archive
   # RHEL 9 unwanted entries:
   # Was in RHEL only because of Google Chrome, not needed anymore as they use dbus api for tray icon
   - libappindicator

--- a/configs/sst_kernel_maintainers-kernel-base-eln.yaml
+++ b/configs/sst_kernel_maintainers-kernel-base-eln.yaml
@@ -27,6 +27,7 @@ data:
         - kernel-doc
         - kernel-headers
         - kernel-modules
+        - kernel-modules-core
         - kernel-modules-extra
         - kernel-tools
         - libertas-sd8787-firmware
@@ -45,6 +46,7 @@ data:
             - kernel-zfcpdump-modules-extra
         x86_64:
             - kernel-tools-libs
+            - kernel-uki-virt
         aarch64:
             - kernel-tools-libs
         ppc64le:

--- a/configs/sst_kernel_maintainers-kernel-base.yaml
+++ b/configs/sst_kernel_maintainers-kernel-base.yaml
@@ -29,7 +29,6 @@ data:
         - kernel-modules-core
         - kernel-modules-extra
         - kernel-tools
-        - kernel-uki-virt
         - libertas-sd8787-firmware
         - linux-firmware
         - linux-firmware-whence
@@ -48,6 +47,7 @@ data:
             - kernel-zfcpdump-modules-extra
         x86_64:
             - kernel-tools-libs
+            - kernel-uki-virt
         aarch64:
             - kernel-64k
             - kernel-64k-core

--- a/configs/sst_kernel_maintainers-kernel-develdebug.yaml
+++ b/configs/sst_kernel_maintainers-kernel-develdebug.yaml
@@ -13,7 +13,6 @@ data:
         - kernel-debug-modules
         - kernel-debug-modules-core
         - kernel-debug-modules-extra
-        - kernel-debug-uki-virt
         - kernel-devel
         - kernel-devel-matched
         - kernel-headers
@@ -22,6 +21,7 @@ data:
         - c9s
     arch_packages:
         x86_64:
+            - kernel-debug-uki-virt
             - kernel-tools-libs-devel
         aarch64:
             - kernel-64k-debug

--- a/configs/sst_pt_pcp-pcp-grafana.yaml
+++ b/configs/sst_pt_pcp-pcp-grafana.yaml
@@ -129,7 +129,6 @@ data:
     - pcp-pmda-perfevent
     s390x:
     - pcp-pmda-bcc
-    - pcp-pmda-bpf
     - pcp-pmda-bpftrace
     - pcp-pmda-gfs2
     x86_64:

--- a/configs/sst_virtualization-all-eln.yaml
+++ b/configs/sst_virtualization-all-eln.yaml
@@ -43,7 +43,6 @@ data:
     - guestfs-tools
     - libguestfs
     - libguestfs-inspect-icons
-    - libguestfs-winsupport
     - qemu-kvm
     - seabios
     - sevctl
@@ -69,3 +68,24 @@ data:
     - qemu-kvm
     - supermin
     - virt-top
+
+  package_placeholders:
+  # RHEL-specific package, not in Fedora
+  - srpm_name: libguestfs-winsupport
+    build_dependencies:
+    - autoconf
+    - automake
+    - libtool
+    - fuse-devel
+    - gnutls-devel
+    - libattr-devel
+    - libconfig-devel
+    - libgcrypt-devel
+    - libuuid-devel
+    limit_arches:
+    - x86_64
+    rpms:
+    - rpm_name: libguestfs-winsupport
+      description: Add support for Windows guests to virt-v2v and virt-p2v
+      dependencies:
+      - libguestfs

--- a/configs/sst_virtualization-all-eln.yaml
+++ b/configs/sst_virtualization-all-eln.yaml
@@ -46,7 +46,6 @@ data:
     - qemu-kvm
     - seabios
     - sevctl
-    - sgabios
     - supermin
     - virt-p2v
     - virt-top


### PR DESCRIPTION
- Fix state of autoconf-archive in ELN
- kernel-uki-virt is x86_64 specific
- ninfod was dropped from iputils
- No pcp-pmda-bpf on s390x
- Placehold libguestfs-winsupport
- Drop sgabios from ELN
