### PR TITLE
add missing texlive-hopatch, texlive-hypdoc, texlive-pdfcol

### DIFF
--- a/configs/sst_cs_system_management-text-processing.yaml
+++ b/configs/sst_cs_system_management-text-processing.yaml
@@ -36,7 +36,6 @@ data:
   - texlive-anyfontsize
   - texlive-anysize
   - texlive-appendix
-  - texlive-arabxetex
   - texlive-arphic
   - texlive-atbegshi
   - texlive-attachfile
@@ -377,7 +376,6 @@ data:
   - texlive-xesearch
   - texlive-xetex-itrans
   - texlive-xetex-pstricks
-  - texlive-xetex-tibetan
   - texlive-xetexconfig
   - texlive-xetexfontinfo
   - texlive-xifthen

--- a/configs/sst_cs_system_management-text-processing.yaml
+++ b/configs/sst_cs_system_management-text-processing.yaml
@@ -157,7 +157,9 @@ data:
   - texlive-helvetic
   - texlive-hobsub
   - texlive-hologo
+  - texlive-hopatch
   - texlive-hycolor
+  - texlive-hypdoc
   - texlive-hyperref
   - texlive-hyph-utf8
   - texlive-hyphen-base
@@ -257,6 +259,7 @@ data:
   - texlive-parallel
   - texlive-parskip
   - texlive-passivetex
+  - texlive-pdfcol
   - texlive-pdfcolmk
   - texlive-pdfescape
   - texlive-pdflscape


### PR DESCRIPTION
hypdoc.sty, pdfcol.sty, hopatch.sty are moved from oberdiek package into separates
packages hypdoc, pdfcol, hopatch since texlive 2023