### PR TITLE
Extend the GTK workloads

### DIFF
--- a/configs/sst_desktop-gtk3.yaml
+++ b/configs/sst_desktop-gtk3.yaml
@@ -6,7 +6,10 @@ data:
   maintainer: sst_desktop
 
   packages:
+  - gtk-update-icon-cache
   - gtk3
+  - gtk3-devel
+  - gtk3-immodule-xim
 
   labels:
   - eln

--- a/configs/sst_desktop-gtk4.yaml
+++ b/configs/sst_desktop-gtk4.yaml
@@ -7,6 +7,7 @@ data:
 
   packages:
   - gtk4
+  - gtk4-devel
 
   labels:
   - eln


### PR DESCRIPTION
Be explicit about packages that we are already shipping in RHEL 9 in AppStream (and will continue to do so in RHEL 10).