### PR TITLE
Extend the GNOME Desktop workload

### DIFF
--- a/configs/sst_desktop-gnome-desktop-eln.yaml
+++ b/configs/sst_desktop-gnome-desktop-eln.yaml
@@ -8,7 +8,9 @@ data:
   packages:
   - freerdp
   - gdm
+  - glib-networking
   - glib2
+  - glib2-devel
   - glib2-static
   - glib2-tests
   - gnome-backgrounds
@@ -28,6 +30,7 @@ data:
   - gnome-shell-extension-workspace-indicator
   - gnome-tweaks
   - gnome-browser-connector
+  - libproxy
   - tracker
   - tracker-miners
   - xdg-user-dirs-gtk

--- a/configs/sst_desktop-gnome-desktop.yaml
+++ b/configs/sst_desktop-gnome-desktop.yaml
@@ -10,7 +10,9 @@ data:
   - autoconf-archive
   - freerdp
   - gdm
+  - glib-networking
   - glib2
+  - glib2-devel
   - glib2-doc
   - glib2-static
   - glib2-tests
@@ -32,6 +34,7 @@ data:
   - gnome-shell-extension-workspace-indicator
   - gnome-tweaks
   - chrome-gnome-shell
+  - libproxy
   - tracker
   - tracker-miners
   - xdg-user-dirs-gtk


### PR DESCRIPTION
Explicitly list some packages that we are shipping in AppStream/BaseOS and also list libproxy that is needed and we're actually moving it to our subsystem for RHEL 10.