### PR TITLE
System tracing: move bpftrace to common packages

### DIFF
--- a/configs/sst_kernel_tps-tracing.yaml
+++ b/configs/sst_kernel_tps-tracing.yaml
@@ -13,18 +13,12 @@ data:
   - libtracefs
   - libtraceevent
   - kernelshark
+  - bpftrace
 
   arch_packages:
     aarch64:
-      - bpftrace
       - opencsd
       - opencsd-devel
-    ppc64le:
-      - bpftrace
-    s390x:
-      - bpftrace
-    x86_64:
-      - bpftrace
 
   labels:
   - eln


### PR DESCRIPTION
bpftrace was originally listed in each architecture b/c it was not present on the armv7hl. AFAIK, this arch is not supported in ELN/CentOS Stream anymore, so move bpftrace to the common list of packages.