### PR TITLE
Update of the Security Compliance workflows for 10

### DIFF
--- a/configs/sst_security_compliance-installation.yaml
+++ b/configs/sst_security_compliance-installation.yaml
@@ -11,5 +11,4 @@ data:
   - scap-security-guide
 
   labels:
-  - eln
   - c9s

--- a/configs/sst_security_compliance-unwanted-eln.yaml
+++ b/configs/sst_security_compliance-unwanted-eln.yaml
@@ -1,0 +1,33 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Unwanted Packages -- Security Compliance (ELN)
+  description: Packages that Security Compliance won't distribute in ELN
+  maintainer: sst_security_compliance
+  labels:
+    - eln
+
+  unwanted_packages:
+    # dependency of oscap-anaconda-addon, because it's the only user, we do not
+    # want to maintain it separately
+    - python3-cpio
+
+    # these pieces were part of Atomic Scan support in RHEL7, and we do not
+    # expect to need them moving forward
+    - openscap-daemon
+    - openscap-container
+
+    # these (stray) packages are maintained by Security Compliance only formally
+    # and should not be included without prior discussion
+    - libtnc
+    - tncfhh
+    - petera
+
+    # this utility should not be included at this moment
+    - oval-graph
+
+    # Hardening during installation is no longer supplied through Anaconda plugin
+    - oscap-anaconda-addon
+
+    # Tailoring of profiles is no longer supplied through SCAP Workbench GUI app
+    - scap-workbench

--- a/configs/sst_security_compliance-workbench.yaml
+++ b/configs/sst_security_compliance-workbench.yaml
@@ -10,5 +10,4 @@ data:
   - openscap-scanner
 
   labels:
-  - eln
   - c9s


### PR DESCRIPTION
There are two expected changes within the RHEL10 timeframe
* change of the way how we harden installation
* removal of the old SCAP Workbench GUI tool