### PR TITLE
Move XDP workload to networking SST

### DIFF
--- a/configs/sst_networking-xdp.yaml
+++ b/configs/sst_networking-xdp.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: XDP
   description: Tools to support XDP
-  maintainer: sst_kernel_tps
+  maintainer: sst_networking
 
   packages:
   - xdp-tools


### PR DESCRIPTION
Update sst_kernel_tps-xdp.yaml to move the workload to the networking sst where it belongs (since I maintain all the mentioned packages anyway).