### PR TITLE
Fix cli-tools split

### DIFF
--- a/configs/sst_cs_plumbers-cli-tools-c9s.yaml
+++ b/configs/sst_cs_plumbers-cli-tools-c9s.yaml
@@ -31,5 +31,4 @@ data:
   - words
 
   labels:
-  - eln
   - c9s


### PR DESCRIPTION
The `eln` tag was left accidently in the split-out c9s config from #888.
