### PR TITLE
Remove Hesiod workload

### DIFF
--- a/configs/ssg_idm-hesiod.yaml
+++ b/configs/ssg_idm-hesiod.yaml
@@ -8,7 +8,6 @@ data:
     packages: []
 
     labels:
-        - eln
         - c9s
 
     package_placeholders:


### PR DESCRIPTION
Hesiod has been deprecated since RHEL 7 and was on ACG Level 1 compatibility. It can finally be removed in RHEL10.