### PR TITLE
Marking nvme-stas as unwanted.

### DIFF
--- a/configs/sst_storage_io-packages-unwanted-c9s.yaml
+++ b/configs/sst_storage_io-packages-unwanted-c9s.yaml
@@ -1,0 +1,13 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Unwanted SST Storage-IO packages
+  description: Unwanted SST Storage-IO and Components
+  maintainer: sst_storage_io
+
+  unwanted_packages:
+  - libhbaapi
+  - libhbalinux
+
+  labels:
+  - c9s

--- a/configs/sst_storage_io-packages-unwanted-eln.yaml
+++ b/configs/sst_storage_io-packages-unwanted-eln.yaml
@@ -8,7 +8,7 @@ data:
   unwanted_packages:
   - libhbaapi
   - libhbalinux
+  - nvme-stas
 
   labels:
   - eln
-  - c9s


### PR DESCRIPTION
This package is going to be delivered via EPEL instead of RHEL in the future.

Since this package has a component in c9s, the 'unwanted' files are getting split by the eln and c9s labels so that we can distinguish between the releases.

This was formerly PR https://github.com/minimization/content-resolver-input/pull/905  I have rebased and created this new PR.