### PR TITLE
sst_java: Updating the JMC ELN workload to reflect changes in packaging

### DIFF
--- a/configs/sst_java-jmc-eln.yaml
+++ b/configs/sst_java-jmc-eln.yaml
@@ -3,10 +3,7 @@ version: 1
 data:
   name: JMC
   description: JDK Mission Control application and libraries
-  maintainer: sst_dotnet_java
-
-  modules_enable:
-  - jmc:7
+  maintainer: sst_java
   
   packages: []
 
@@ -14,7 +11,5 @@ data:
     x86_64:
     - jmc
     - jmc-core
-    - eclipse-pde
-    - tycho
   labels:
   - eln

--- a/configs/sst_java-jmc-eln.yaml
+++ b/configs/sst_java-jmc-eln.yaml
@@ -9,7 +9,21 @@ data:
 
   arch_packages:
     x86_64:
-    - jmc
-    - jmc-core
+    
+  package_placeholders: 
+      srpm_name: jmc
+      limit_arches: x86_64
+      rpms:
+        rpm_name: jmc
+        description: JDK Mission Control package
+        limit_arches: x86_64
+      
+      srpm_name: jmc-core
+      limit_arches: x86_64
+      rpms:
+        rpm_name: jmc-core
+        description: JDK Mission Control core library
+        limit_arches: x86_64
+     
   labels:
   - eln

--- a/configs/sst_java-jmc-eln.yaml
+++ b/configs/sst_java-jmc-eln.yaml
@@ -6,9 +6,6 @@ data:
   maintainer: sst_java
   
   packages: []
-
-  arch_packages:
-    x86_64:
     
   package_placeholders: 
     - srpm_name: jmc

--- a/configs/sst_java-jmc-eln.yaml
+++ b/configs/sst_java-jmc-eln.yaml
@@ -11,19 +11,35 @@ data:
     x86_64:
     
   package_placeholders: 
-      srpm_name: jmc
-      limit_arches: x86_64
+    - srpm_name: jmc
+      build_dependencies:
+      - desktop-file-utils
+      - java-17-openjdk-devel
+      - maven-local
+      limit_arches:
+      - x86_64
       rpms:
-        rpm_name: jmc
+      - rpm_name: jmc
         description: JDK Mission Control package
-        limit_arches: x86_64
+        dependencies:
+        - gtk3
+        - java-17-openjdk
+        - mesa-libGLU
+        - webkit2gtk4.1
+        limit_arches:
+        - x86_64
       
-      srpm_name: jmc-core
-      limit_arches: x86_64
+    - srpm_name: jmc-core
+      build_dependencies:
+      - maven-local
+      limit_arches:
+      - x86_64
       rpms:
-        rpm_name: jmc-core
+      - rpm_name: jmc-core
         description: JDK Mission Control core library
-        limit_arches: x86_64
+        dependencies: []
+        limit_arches:
+        - x86_64
      
   labels:
   - eln


### PR DESCRIPTION
- Removing the eclipse-pde and tycho packages since they're no longer needed and have been removed
- Correcting the SST name to sst_java
- Removing the JMC 7 module