### PR TITLE
ELN warning fixes, round 4

### DIFF
--- a/configs/sst_container_tools.yaml
+++ b/configs/sst_container_tools.yaml
@@ -25,17 +25,17 @@ data:
    - netavark
    - oci-seccomp-bpf-hook
    - podman
-   - python-podman
+   - python3-podman
    - runc
    - skopeo
    - slirp4netns
    - toolbox
    - udica
-   - yayl
+   - yajl
 
   labels:
   - c9s
 
   unwanted_packages:
-    - python-podman-api
+    - python3-podman-api
 

--- a/configs/sst_container_tools_eln.yaml
+++ b/configs/sst_container_tools_eln.yaml
@@ -12,7 +12,6 @@ data:
    - buildah
    - catatonit
    - cockpit-podman
-   - container-tools
    - container-selinux
    - containers-common
    - conmon
@@ -23,17 +22,25 @@ data:
    - netavark
    - oci-seccomp-bpf-hook
    - podman
-   - python-podman
+   - python3-podman
    - skopeo
    - toolbox
    - udica
-   - yayl
+   - yajl
+
+  package_placeholders:
+   - srpm_name: container-tools
+     build_dependencies: []
+     rpms:
+      - rpm_name: container-tools
+        description: Meta-package for container tools
+        dependencies: []
 
   labels:
   - eln
 
   unwanted_packages:
     - containernetworking-plugins
-    - python-podman-api
+    - python3-podman-api
     - runc
     - slirp4netns

--- a/configs/sst_program-lorax-template-eln.yaml
+++ b/configs/sst_program-lorax-template-eln.yaml
@@ -12,7 +12,6 @@ data:
   - anaconda-widgets
   - kexec-tools-anaconda-addon
   - anaconda-install-env-deps
-  - oscap-anaconda-addon
   - dnf
   - rpm-ostree
   - ostree

--- a/configs/sst_pt_llvm_rust_go-go-toolset.yaml
+++ b/configs/sst_pt_llvm_rust_go-go-toolset.yaml
@@ -14,27 +14,14 @@ data:
   - golang-tests
   - go-srpm-macros
   - go-rpm-macros
+  - go-toolset
 
   arch_packages:
+    aarch64:
+      - delve
     x86_64:
-      - golang-race
+      - delve
 
   labels:
   - eln
   - c9s
-
-  package_placeholders:
-    delve:
-      srpm: delve
-      description: This package is not in Fedora (yet), but we want to see it here.
-      requires: []
-      buildrequires:
-      - golang
-      - git
-      - lsof
-    go-toolset:
-      srpm: go-toolset
-      description: Meta-package for go-toolset
-      requires:
-        - golang
-      buildrequires: []

--- a/configs/sst_virtualization_windows-subsystem.yaml
+++ b/configs/sst_virtualization_windows-subsystem.yaml
@@ -11,11 +11,10 @@ data:
   - eln
   - c9s
 
+  # RHEL-specific packages, not in Fedora
   package_placeholders:
-    mingw-qemu-ga-win:
-      srpm: mingw-qemu-ga-win
-      description: Qemus Guest agent for Windows
-      buildrequires:
+    - srpm_name: mingw-qemu-ga-win
+      build_dependencies:
         - libtool
         - zlib-devel
         - glib2-devel
@@ -34,10 +33,15 @@ data:
         - msitools
         - meson
         - ninja-build
-    virtio-win:
-      srpm: virtio-win
-      description: This package is only provided in RHEL
-      buildrequires:
+      limit_arches:
+        - x86_64
+      rpms:
+        - rpm_name: mingw-qemu-ga-win
+          description: Qemus Guest agent for Windows
+          dependencies:
+            - systemd-units
+    - srpm_name: virtio-win
+      build_dependencies:
         - mingw32-pixman
         - mingw64-pixman
         - mingw32-gcc
@@ -67,6 +71,10 @@ data:
         - mingw-binutils-generic
         - mingw-filesystem-base
         - mingw-w64-tools
-        - mingw-pcre
-        - mingw-zlib
-        - mingw-libffi
+        - xorriso
+      limit_arches:
+        - x86_64
+      rpms:
+        - rpm_name: virtio-win
+          description: VirtIO para-virtualized drivers for Windows
+          dependencies: []


### PR DESCRIPTION
- Drop oscap-anaconda-addon from ELN lorax template
- Fix warnings in Windows Virt
- Fix warnings in container-tools
- Update go-toolset
