### PR TITLE
drop redundant eln-candidate labels

### DIFF
--- a/configs/rhel-8-appstream-comps-performance.yaml
+++ b/configs/rhel-8-appstream-comps-performance.yaml
@@ -2,7 +2,6 @@
 data:
   description: Automatically generated.
   labels:
-  - eln-candidate
   - eln
   - c9s
   maintainer: sst_pt_pcp

--- a/configs/sst_i18n-langpacks-eln.yaml
+++ b/configs/sst_i18n-langpacks-eln.yaml
@@ -5,7 +5,6 @@ data:
   description: A set of Language packs metapackages
   maintainer: sst_i18n
   labels:
-  - eln-candidate
   - eln
 
   options:

--- a/configs/sst_i18n-tools.yaml
+++ b/configs/sst_i18n-tools.yaml
@@ -15,4 +15,3 @@ data:
   labels:
   - eln
   - c9s
-  - eln-candidate


### PR DESCRIPTION
These are not used or needed anymore.