### PR TITLE
remove opal-firmware for ELN

### DIFF
--- a/configs/sst_cs_system_management-sys-management-c9s.yaml
+++ b/configs/sst_cs_system_management-sys-management-c9s.yaml
@@ -8,5 +8,9 @@ data:
   packages:
   - usermode-gtk
 
+  arch_packages:
+    ppc64le:
+    - opal-firmware
+
   labels:
   - c9s

--- a/configs/sst_cs_system_management-sys-management.yaml
+++ b/configs/sst_cs_system_management-sys-management.yaml
@@ -96,7 +96,6 @@ data:
     - setserial
     - opal-prd
     - opal-utils
-    - opal-firmware
     - powerpc-utils
     - powerpc-utils-core
     - ppc64-diag


### PR DESCRIPTION
Remove opal-firmware subpackage for ELN as qemu doesn't require it any more, but keep it for c9s.