### PR TITLE
Drop xorg-x11-drv-v4l from ELN X11 server

### DIFF
--- a/configs/sst_gpu-X11-server-c9s.yaml
+++ b/configs/sst_gpu-X11-server-c9s.yaml
@@ -23,6 +23,7 @@ data:
     - xorg-x11-drv-fbdev
     - xorg-x11-drv-libinput
     - xorg-x11-drv-modesetting
+    - xorg-x11-drv-v4l
     - xorg-x11-drv-wacom
     ppc64le:
     # xorg-x11-drivers
@@ -31,6 +32,7 @@ data:
     - xorg-x11-drv-fbdev
     - xorg-x11-drv-libinput
     - xorg-x11-drv-modesetting
+    - xorg-x11-drv-v4l
     - xorg-x11-drv-wacom
     x86_64:
     # xorg-x11-drivers
@@ -39,8 +41,9 @@ data:
     - xorg-x11-drv-fbdev
     - xorg-x11-drv-libinput
     - xorg-x11-drv-modesetting
+    - xorg-x11-drv-v4l
     - xorg-x11-drv-vmware
     - xorg-x11-drv-wacom
 
   labels:
-    - eln
+    - c9s


### PR DESCRIPTION
Upstream development of this driver has ceased, and the package was orphaned by the maintainer in Fedora:

https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/AAKVIAL7ZOAZOTCSYZUWJN4XAZCQBFU6/
