### PR TITLE
Rename workloads maintainer for sst_network_management

### DIFF
--- a/configs/sst_networking-management-core.yaml
+++ b/configs/sst_networking-management-core.yaml
@@ -5,7 +5,7 @@ data:
   description: >
     The Core Network Management tools for the local host. This includes
     NetworkManager and related tools.
-  maintainer: sst_networking
+  maintainer: sst_network_management
   packages:
   - dhcp-client
   - dnsmasq

--- a/configs/sst_networking-management-desktop.yaml
+++ b/configs/sst_networking-management-desktop.yaml
@@ -5,7 +5,7 @@ data:
   description: >
     The Network Management tools for the desktop environment, including
     bluetooh, WIFI, IPSec VPN, Cellular network supports.
-  maintainer: sst_networking
+  maintainer: sst_network_management
   packages:
   # Core
   - iproute

--- a/configs/sst_networking-management-devel.yaml
+++ b/configs/sst_networking-management-devel.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Network Management in Development
   description: The Network Management tools for the development environment.
-  maintainer: sst_networking
+  maintainer: sst_network_management
   packages:
   # Core
   - iproute

--- a/configs/sst_networking-management-server-c9s.yaml
+++ b/configs/sst_networking-management-server-c9s.yaml
@@ -6,7 +6,7 @@ data:
     The Network Management tools for the server environment, including Open
     vSwitch, Team, ADSL, cloud, source routing supports, nmstate, IPSec VPN,
     Cellular network supports.
-  maintainer: sst_networking
+  maintainer: sst_network_management
   packages:
   # Core
   - iproute

--- a/configs/sst_networking-management-server.yaml
+++ b/configs/sst_networking-management-server.yaml
@@ -6,7 +6,7 @@ data:
     The Network Management tools for the server environment, including Open
     vSwitch, ADSL, cloud, source routing supports, nmstate, IPSec VPN,
     Cellular network supports.
-  maintainer: sst_networking
+  maintainer: sst_network_management
   packages:
   # Core
   - iproute


### PR DESCRIPTION
Networking SST is split into several SSTs - This PR is to update the content resolver for the Network Management SST. 