### PR TITLE
Update some ELN placeholders

### DIFF
--- a/configs/sst_cs_apps-db-mysql.yaml
+++ b/configs/sst_cs_apps-db-mysql.yaml
@@ -31,6 +31,7 @@ data:
         - make
         - mecab-devel
         - multilib-rpm-config
+        - mysql-selinux
         - openssl
         - openssl-devel
         - perl-base
@@ -97,8 +98,6 @@ data:
           dependencies:
             - libzstd
             - openssl-libs
-        - rpm_name: mysql-selinux
-          description: MySQL is called community-mysql in Fedora, but we want mysql name in RHEL
         - rpm_name: mysql-server
           description: MySQL is called community-mysql in Fedora, but we want mysql name in RHEL
           dependencies:
@@ -107,6 +106,7 @@ data:
             - lz4-libs
             - mecab-ipadic
             - mecab-ipadic-EUCJP
+            - mysql-selinux
             - openssl-libs
             - perl-Getopt-Long
             - perl-libs

--- a/configs/sst_cs_infra_services-time-synchronization.yaml
+++ b/configs/sst_cs_infra_services-time-synchronization.yaml
@@ -7,7 +7,6 @@ data:
 
   packages:
   - chrony
-  - gpsd-minimal
   - linuxptp
   - ntpstat
   - synce4l

--- a/configs/sst_cs_plumbers-base.yaml
+++ b/configs/sst_cs_plumbers-base.yaml
@@ -27,16 +27,9 @@ data:
   - systemd-journal-remote
   - systemd-udev
   - polkit
+  - zram-generator
+  - zram-generator-defaults
 
   labels:
   - eln
   - c9s
-
-  package_placeholders:
-    zram-generator:
-      description: RHEL builds are bundled and use rust-toolset
-      srpm: rust-zram-generator
-    zram-generator-defaults:
-      description: RHEL builds are bundled and use rust-toolset
-      srpm: rust-zram-generator
-

--- a/configs/sst_desktop_applications-tigervnc.yaml
+++ b/configs/sst_desktop_applications-tigervnc.yaml
@@ -7,21 +7,10 @@ data:
 
   packages:
   - tigervnc
+  - tigervnc-selinux
   - tigervnc-server
   - tigervnc-server-module
 
   labels:
   - eln
   - c9s
-
-  package_placeholders:
-    tigervnc-selinux:
-      srpm: tigervnc
-      description: SELinux module for TigerVNC
-      requires:
-        - libselinux-utils
-        - selinux-policy
-        - policycoreutils
-        - libselinux-utils
-      buildrequires:
-        - selinux-policy-devel

--- a/configs/sst_kernel_rts-kernel-rt-base-eln.yaml
+++ b/configs/sst_kernel_rts-kernel-rt-base-eln.yaml
@@ -8,274 +8,47 @@ data:
     labels:
         - eln
 
+    arch_packages:
+      x86_64:
+        - tuned-profiles-realtime
+        - tuned-profiles-nfv
+        - tuned-profiles-nfv-guest
+        - tuned-profiles-nfv-host
+
+    # RHEL-specific subpackages, not available in Fedora
     package_placeholders:
-      kernel-rt:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-        limit_arches:
-          - x86_64
+      - srpm_name: kernel
+        build_dependencies: []
+        rpms:
+          - rpm_name: kernel-rt
+            dependencies:
+              - realtime-setup
+            limit_arches:
+              - x86_64
+          - rpm_name: kernel-rt-core
+            dependencies:
+              - bash
+              - systemd-udev
+              - coreutils
+              - dracut
+              - linux-firmware
+              - systemd
+            limit_arches:
+              - x86_64
+          - rpm_name: kernel-rt-modules
+            dependencies: []
+            limit_arches:
+              - x86_64
+          - rpm_name: kernel-rt-modules-core
+            dependencies: []
+            limit_arches:
+              - x86_64
+          - rpm_name: kernel-rt-modules-extra
+            dependencies: []
+            limit_arches:
+              - x86_64
+          - rpm_name: kernel-rt-kvm
+            dependencies: []
+            limit_arches:
+              - x86_64
 
-      kernel-rt-core:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-        limit_arches:
-          - x86_64
-
-      kernel-rt-modules:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-        limit_arches:
-          - x86_64
-
-      kernel-rt-modules-extra:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-        limit_arches:
-          - x86_64
-
-      kernel-rt-kvm:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-        limit_arches:
-          - x86_64
-
-      tuned-profiles-realtime:
-        srpm: tuned
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - man
-        limit_arches:
-          - x86_64
-
-      tuned-profiles-nfv:
-        srpm: tuned
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - man
-        limit_arches:
-          - x86_64
-
-      tuned-profiles-nfv-guest:
-        srpm: tuned
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - man
-        limit_arches:
-          - x86_64
-
-      tuned-profiles-nfv-host:
-        srpm: tuned
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - man
-        limit_arches:
-          - x86_64

--- a/configs/sst_kernel_rts-kernel-rt-develdebug-eln.yaml
+++ b/configs/sst_kernel_rts-kernel-rt-develdebug-eln.yaml
@@ -8,400 +8,64 @@ data:
     labels:
         - eln 
 
+    # RHEL-specific subpackages, not available in Fedora
     package_placeholders:
-      kernel-rt-debug:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-        limit_arches:
-          - x86_64
+      - srpm_name: kernel
+        build_dependencies: []
+        rpms:
+          - rpm_name: kernel-rt-debug
+            dependencies:
+              - realtime-setup
+            limit_arches:
+              - x86_64
+          - rpm_name: kernel-rt-debug-core
+            dependencies:
+              - bash
+              - systemd-udev
+              - coreutils
+              - dracut
+              - linux-firmware
+              - systemd
+            limit_arches:
+              - x86_64
+          - rpm_name: kernel-rt-debug-modules
+            dependencies: []
+            limit_arches:
+              - x86_64
+          - rpm_name: kernel-rt-debug-modules-core
+            dependencies: []
+            limit_arches:
+              - x86_64
+          - rpm_name: kernel-rt-debug-modules-extra
+            dependencies: []
+            limit_arches:
+              - x86_64
+          - rpm_name: kernel-rt-debug-kvm
+            dependencies: []
+            limit_arches:
+              - x86_64
+          - rpm_name: kernel-rt-debug-devel
+            dependencies:
+              - bison
+              - elfutils-libelf-devel
+              - findutils
+              - flex
+              - gcc
+              - make
+              - openssl-devel
+              - perl-interpreter
+            limit_arches:
+              - x86_64
+          - rpm_name: kernel-rt-devel
+            dependencies:
+              - bison
+              - elfutils-libelf-devel
+              - findutils
+              - flex
+              - gcc
+              - make
+              - openssl-devel
+              - perl-interpreter
+            limit_arches:
+              - x86_64
 
-      kernel-rt-debug-core:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-        limit_arches:
-          - x86_64
-
-      kernel-rt-debug-modules:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-        limit_arches:
-          - x86_64
-
-      kernel-rt-debug-modules-extra:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-        limit_arches:
-          - x86_64
-
-      kernel-rt-debug-kvm:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-        limit_arches:
-          - x86_64
-
-      kernel-rt-debuginfo-common-x86_64:
-        srpm: kernel-rt
-        description: files used by kernel-rt-debuginfo
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        limit_arches:
-          - x86_64
-
-      kernel-rt-debuginfo:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          # asamalik: I'm removing this package as it's a placeholder
-          #           and the current logic won't see it and fail the whole workload.
-          #           This won't affect anything as the kernel-rt-debuginfo-common-x86_64
-          #           is present in this workload anyway (listed below), so it'll still be
-          #           on the output.
-          # - kernel-rt-debuginfo-common-x86_64
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-          - rpm-build
-          - elfutils
-        limit_arches:
-          - x86_64
-
-      kernel-rt-devel:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-        limit_arches:
-          - x86_64
-
-      kernel-rt-debug-devel:
-        srpm: kernel-rt
-        description: This package is not in Fedora (yet), but we want it here.
-        requires:
-          - bash
-          - systemd-udev
-          - coreutils
-          - dracut
-          - linux-firmware
-          - systemd
-        buildrequires:
-          - kmod
-          - patch
-          - bash
-          - coreutils
-          - tar
-          - git
-          - which
-          - bzip2
-          - xz
-          - findutils
-          - gzip
-          - m4
-          - perl-interpreter
-          - perl-Carp
-          - perl-devel
-          - perl-generators
-          - make
-          - diffutils
-          - gawk
-          - gcc
-          - binutils
-          - redhat-rpm-config
-          - hmaccalc
-          - python3-devel
-          - net-tools
-          - hostname
-          - bc
-          - bison
-          - flex
-          - elfutils-devel
-          - dwarves
-          - openssl
-          - openssl-devel
-        limit_arches:
-          - x86_64

--- a/configs/sst_logical_storage-packages.yaml
+++ b/configs/sst_logical_storage-packages.yaml
@@ -45,21 +45,38 @@ data:
     - lvm2-lockd
     - mdadm
     - sanlock
+    - stratisd
     - userspace-rcu
 
+  # RHEL-specific packages, not available in Fedora
   package_placeholders:
-    kmod-kvdo:
-      description: This package is currently only available in RHEL.  (Fedora package is available via COPR)
-      srpm: kmod-kvdo
-    pmreorder:
-      description: This package is only available in RHEL.
-      srpm: pmreorder
-    vdo:
-      description: This package is currently only available in RHEL.  (Fedora package is available via COPR)
-      srpm: vdo
-    stratisd:
-      description: RHEL builds are bundled and use rust-toolset.  Placeholder so we do not pull in Fedoras dependencies.
-      srpm: stratisd
+    - srpm_name: kmod-kvdo
+      build_dependencies:
+        - elfutils-libelf-devel
+        - kernel-devel
+        - libuuid-devel
+      rpms:
+        - rpm_name: kmod-kvdo
+          description: Kernel Modules for Virtual Data Optimizer
+          dependencies:
+            - kernel-core
+            - kernel-modules
+    - srpm_name: vdo
+      build_dependencies:
+        - libblkid-devel
+        - libuuid-devel
+        - device-mapper-devel
+        - device-mapper-event-devel
+        - valgrind-devel
+        - zlib-devel
+      rpms:
+        - rpm_name: vdo
+          description: Management tools for Virtual Data Optimizer
+          dependencies:
+            - libblkid
+            - libuuid
+            - device-mapper-event-libs
+            - zlib
 
   labels:
   - eln

--- a/configs/sst_pt_llvm_rust_go-llvm-toolset-c9s.yaml
+++ b/configs/sst_pt_llvm_rust_go-llvm-toolset-c9s.yaml
@@ -29,24 +29,28 @@ data:
     aarch64:
       - libomp
       - libomp-devel
+      - libomp-test
       - lld
       - lld-devel
       - lld-libs
     ppc64le:
       - libomp
       - libomp-devel
+      - libomp-test
       - lld
       - lld-devel
       - lld-libs
     x86_64:
       - libomp
       - libomp-devel
+      - libomp-test
       - lld
       - lld-devel
       - lld-libs
     armv7hl:
       - libomp
       - libomp-devel
+      - libomp-test
 
   labels:
-  - eln
+  - c9s


### PR DESCRIPTION
This should cover all ELN placeholders which are now already pulled in as real packages.  As well, update kernel-rt and libomp for downstream packaging changes.

- Drop LLVM libomp-test from ELN
- Unplacehold zram-generator
- Update storage placeholders
- Fix mysql-selinux
- Update kernel-rt placeholders
- Unplacehold tigervnc-selinux
