### PR TITLE
DRAFT: crypto: intel: packages are arch specific

### DIFF
--- a/configs/sst_security_crypto-intel.yaml
+++ b/configs/sst_security_crypto-intel.yaml
@@ -5,10 +5,11 @@ data:
   description: libraries needed for acceleration of crypto and compression on Intel processors
   maintainer: sst_security_crypto
 
-  packages:
-  - intel-ipsec-mb
-  - intel-ipp-crypto-mb
-
   labels:
   - eln
   - c9s
+
+  arch_packages:
+    x86_64:
+      - intel-ipsec-mb
+      - intel-ipp-crypto-mb


### PR DESCRIPTION
These packages are x86_64 only.