### PR TITLE
Make it easier to detect that GHC was included by accident

### DIFF
--- a/configs/sst_program-unwanted.yaml
+++ b/configs/sst_program-unwanted.yaml
@@ -50,6 +50,7 @@ data:
     - koji-utils
     - koji-vm
     - koji-web
+    - pandoc
     - python3-koji
     - python3-koji-cli-plugins
     - python3-koji-hub


### PR DESCRIPTION
GHC uses versioned packages (ghc9.8), so the previous unwanted package entry did not match it.  List a few common GHC packages as well: alex (lexer generator), happy (parser generator), and ghc-bytes, ghc-bytes (libraries fairly central to binary data processing).