### PR TITLE
Gate awscli2 out of s390x for the Meta ELN Extras config

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -96,11 +96,6 @@ data:
       - awscli2
       - sedutil
       - sysbench
-    i686:
-      - awscli2
-      - msr-tools
-      - sedutil
-      - sysbench
     ppc64le:
       - awscli2
       - sedutil

--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -8,7 +8,6 @@ data:
   packages:
   - atop
   - awscli
-  - awscli2
   - azure-cli
   - b4
   - below
@@ -94,15 +93,19 @@ data:
 
   arch_packages:
     aarch64:
+      - awscli2
       - sedutil
       - sysbench
     i686:
+      - awscli2
       - msr-tools
       - sedutil
       - sysbench
     ppc64le:
+      - awscli2
       - sedutil
     x86_64:
+      - awscli2
       - msr-tools
       - sedutil
       - sysbench


### PR DESCRIPTION
This package has an ExcludeArch on s390x so we need to gate it out to unbreak the workload.