### PR TITLE
Remove ESC package from base RHEL

### DIFF
--- a/configs/ssg_idm-smart-cards-unwanted.yaml
+++ b/configs/ssg_idm-smart-cards-unwanted.yaml
@@ -1,12 +1,12 @@
-document: feedback-pipeline-workload
+document: feedback-pipeline-unwanted
 version: 1
 data:
-  name: IdM Smart Cards (RHCS specific)
+  name: IdM Smart Cards unwanted (RHCS specific)
   description: Specific packages for client-side smart card enrollment on RHEL.
   maintainer: ssg_idm
 
-  packages:
-  - esc
+  unwanted_packages:
+    - esc
 
   labels:
-  - c9s
+    - eln


### PR DESCRIPTION
The ESC is a tool for RHCS smart cards enrollment and it should be moved to the RHCS layered product. It has very limited use in base RHEL.