### PR TITLE
Mark aopalliance and jsoup as wanted in ELN

### DIFF
--- a/configs/sst_cs_apps-unwanted-java-c9s.yaml
+++ b/configs/sst_cs_apps-unwanted-java-c9s.yaml
@@ -64,4 +64,4 @@ data:
   - xml-maven-plugin
 
   labels:
-  - eln
+  - c9s

--- a/configs/sst_cs_apps-unwanted-java.yaml
+++ b/configs/sst_cs_apps-unwanted-java.yaml
@@ -7,7 +7,6 @@ data:
 
   unwanted_source_packages:
   - ant-contrib
-  - aopalliance
   - apache-commons-exec
   - apache-commons-lang
   - apache-ivy
@@ -36,7 +35,6 @@ data:
   - jaxen
   - jboss-modules
   - jmock
-  - jsoup
   - jtidy
   - log4j12
   - maven-artifact-resolver


### PR DESCRIPTION
* aopalliance is now dependency of google-guice, required by Maven workload. It will be in AppStream.
* jsoup will be in buildroot/CRB as it's a transitive build depedency of Maven.