### PR TITLE
Mark plexus-build-api as unwanted in ELN

### DIFF
--- a/configs/sst_cs_apps-unwanted-java.yaml
+++ b/configs/sst_cs_apps-unwanted-java.yaml
@@ -51,6 +51,7 @@ data:
   - maven-script-interpreter
   - objectweb-pom
   - os-maven-plugin
+  - plexus-build-api
   - plexus-component-api
   - plexus-i18n
   - plexus-interactivity


### PR DESCRIPTION
In ELN plexus-build-api >= 1.0.0 is unwanted.
Instead in ELN we want compat package plexus-build-api0 version 0.0.7.