### PR TITLE
geocode-glib is wanted in ELN again

### DIFF
--- a/configs/sst_desktop-unwanted-eln.yaml
+++ b/configs/sst_desktop-unwanted-eln.yaml
@@ -92,9 +92,6 @@ data:
   # The functionality was moved into GNOME Shell itself
   # https://pagure.io/fedora-workstation/issue/277
   - gnome-screenshot
-  # Obsoleted by geocode-glib2 that is using libsoup3
-  - geocode-glib
-  - geocode-glib-devel
   # Only espeak-ng is the supported speech synthetizer in RHEL 10
   - festival
   - flite


### PR DESCRIPTION
The libsoup2-based geocode-glib-1.0 API is no longer used, and therefore has been dropped from Fedora 39 entirely; the libsoup3-based geocode-glib-2.0 API previously packaged as geocode-glib2 is now packaged as geocode-glib:

https://src.fedoraproject.org/rpms/geocode-glib/c/bb0eab3abdb68f1646967220071254cea17a3f6c
https://src.fedoraproject.org/rpms/geocode-glib/c/f6cc26c1d5af7570377feae4f4fa5e6ef3876e56
https://src.fedoraproject.org/rpms/geocode-glib/c/971bb3b5f2b446dae8e96d6291d8d44555fba551

/cc @tpopela
