### PR TITLE
ant-jakartamail replaces ant-javamail in ELN

### DIFF
--- a/configs/sst_cs_apps-java-ant-c9s.yaml
+++ b/configs/sst_cs_apps-java-ant-c9s.yaml
@@ -16,7 +16,7 @@ data:
   - ant-apache-xalan2
   - ant-commons-logging
   - ant-commons-net
-  - ant-jakartamail
+  - ant-javamail
   - ant-jdepend
   - ant-jmf
   - ant-jsch
@@ -27,4 +27,4 @@ data:
   - ant-xz
 
   labels:
-  - eln
+  - c9s


### PR DESCRIPTION
This fixes a new warning triggered by this change in ant 1.10.13:

https://src.fedoraproject.org/rpms/ant/c/017a0402ce77df95c1d481ef33fa01e17b6cc55f

/cc @mizdebsk
