### PR TITLE
Drop scons build dependency from gpsd-minimal

### DIFF
--- a/configs/sst_cs_infra_services-time-synchronization.yaml
+++ b/configs/sst_cs_infra_services-time-synchronization.yaml
@@ -21,7 +21,6 @@ data:
     - python3-devel
     - python3-setuptools
     - gtk3-devel
-    - python3-scons
     - python3-gobject
     - python3-cairo
     - python3-pyserial


### PR DESCRIPTION
scons is being bundled in the gpsd-minimal SRPM in c9s.
