### PR TITLE
Mark javacc as wanted in ELN

### DIFF
--- a/configs/sst_cs_apps-unwanted-java.yaml
+++ b/configs/sst_cs_apps-unwanted-java.yaml
@@ -28,8 +28,6 @@ data:
   - jakarta-ws-rs
   - jakarta-xml-rpc
   - jakarta-xml-ws
-  - javacc
-  - javacc-maven-plugin
   - javamail
   - javassist
   - jaxen


### PR DESCRIPTION
Packages javacc and javacc-maven-plugin are no longer unwanted in ELN.
Thy are now transitive build-dependencies of maven in rawhide.