### PR TITLE
Remove QGnomePlatform with Adwaita-qt and include QAdwaitaDecorations

### DIFF
--- a/configs/sst_desktop_applications-qt6.yaml
+++ b/configs/sst_desktop_applications-qt6.yaml
@@ -87,7 +87,6 @@ data:
   - qt6-rpm-macros
   - qt6-srpm-macros
   # GNOME integration
-  - adwaita-qt6
-  - qgnomeplatform-qt6
+  - qadwaitadecorations-qt6
   labels:
   - eln

--- a/configs/sst_desktop_applications-unwanted-eln.yaml
+++ b/configs/sst_desktop_applications-unwanted-eln.yaml
@@ -46,11 +46,13 @@ data:
   - file-roller
   # Only Qt 6 will be part of RHEL 10
   # Qt 6
-  # Not needed as we have qgnomeplatform in RHEL
   - qt6ct
   - qt6-qtwebengine
   - qt6-qtwebengine-devtools
   - qt6-qtwebview
+  # Deprecated Qt/GNOME integration
+  - qgnomeplatform-qt6
+  - adwaita-qt6
   # Qt 5
   - adwaita-qt5
   - qgnomeplatform-qt5


### PR DESCRIPTION
This is following Fedora 39 change, where QGnomePlatform and Adwaita-qt are removed in favor of Qt's default integration and partially replaced with a new client-side window decoration plugin.
Link: [Fedora 39 feature](https://fedoraproject.org/wiki/Changes/NoCustomQtThemingForWorkstation)
RedHat tracker: [DESKTOP-735](https://issues.redhat.com/browse/DESKTOP-735)