### PR TITLE
replace iotop with iotop-c in ELN

### DIFF
--- a/configs/sst_cs_system_management-sys-monitoring-c9s.yaml
+++ b/configs/sst_cs_system_management-sys-monitoring-c9s.yaml
@@ -6,7 +6,7 @@ data:
   maintainer: sst_cs_system_management
 
   packages:
-  - iotop-c
+  - iotop
   - net-snmp
   - net-snmp-devel
   - net-snmp-libs
@@ -21,4 +21,4 @@ data:
     - servicelog
 
   labels:
-  - eln
+  - c9s


### PR DESCRIPTION
Replace iotop with iotop-c forn ELN. Currently, iotop has often screen issues, close to zero upstream development, latest release is 10yrs old and is bigger (python). iotop-c is compatible drop-in replacement with active upstream, smaller, less issues.