### PR TITLE
Add post-quantum crypto: liboqs, oqs-provider

### DIFF
--- a/configs/sst_security_crypto-pqc.yaml
+++ b/configs/sst_security_crypto-pqc.yaml
@@ -1,0 +1,12 @@
+---
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: post-quantum cryptography
+  description: Components providing post-quantum cryptography primitives.
+  maintainer: sst_security_crypto
+  packages:
+    - liboqs
+    - oqs-provider
+  labels:
+    - eln


### PR DESCRIPTION
Since there is industry demand for post-quantum cryptography, add the recently packaged liboqs and oqs-provider packages as requested for eln.