### PR TITLE
post-quantum crypto: Fix package name typo

### DIFF
--- a/configs/sst_security_crypto-pqc.yaml
+++ b/configs/sst_security_crypto-pqc.yaml
@@ -7,6 +7,6 @@ data:
   maintainer: sst_security_crypto
   packages:
     - liboqs
-    - oqs-provider
+    - oqsprovider
   labels:
     - eln


### PR DESCRIPTION
The OpenSSL OQS Provider is packaged in oqsprovider, not oqs-provider.