### PR TITLE
Add CMake to the VFX Platform

### DIFF
--- a/configs/sst_pt_libraries-vfxplatform-c9s.yaml
+++ b/configs/sst_pt_libraries-vfxplatform-c9s.yaml
@@ -7,6 +7,12 @@ data:
 
   packages:
   # The minimum development environment is this:
+  - cmake
+  - cmake-filesystem
+  - cmake-gui
+  - cmake-data
+  - cmake-doc
+  - cmake-rpm-macros
   - gcc
   - gcc-c++
   - binutils

--- a/configs/sst_pt_libraries-vfxplatform-eln.yaml
+++ b/configs/sst_pt_libraries-vfxplatform-eln.yaml
@@ -7,6 +7,12 @@ data:
 
   packages:
   # The minimum development environment is this:
+  - cmake
+  - cmake-filesystem
+  - cmake-gui
+  - cmake-data
+  - cmake-doc
+  - cmake-rpm-macros
   - gcc
   - gcc-c++
   - binutils


### PR DESCRIPTION
This is a required tool for building VFX software and needs to be tracked alongside other components required for the VFX Platform.