### PR TITLE
Mark munge-maven-plugin as unwanted in ELN

### DIFF
--- a/configs/sst_cs_apps-unwanted-java.yaml
+++ b/configs/sst_cs_apps-unwanted-java.yaml
@@ -47,6 +47,7 @@ data:
   - maven-reporting-api
   - maven-reporting-impl
   - maven-script-interpreter
+  - munge-maven-plugin
   - objectweb-pom
   - os-maven-plugin
   - plexus-build-api


### PR DESCRIPTION
munge-maven-plugin has been retired from Fedora rawhide and should be absent in ELN as well.