### PR TITLE
Replace Eye of GNOME with Loupe as the default image viewer

### DIFF
--- a/configs/sst_desktop-loupe.yaml
+++ b/configs/sst_desktop-loupe.yaml
@@ -1,12 +1,13 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: Eye of GNOME
+  name: Loupe
   description: Default image viewer for Workstation
-  maintainer: sst_desktop_applications
+  maintainer: sst_desktop
 
   packages:
-  - eog
+  - loupe
+  - glycin-loaders
 
   labels:
-  - c9s
+  - eln

--- a/configs/sst_desktop_applications-unwanted-eln.yaml
+++ b/configs/sst_desktop_applications-unwanted-eln.yaml
@@ -96,6 +96,8 @@ data:
   - libgdata
   # Replaced by enchant2 and applications should be ported to it
   - enchant
+  # Replaced by Loupe
+  - eog
 
   labels:
   - eln


### PR DESCRIPTION
See https://pagure.io/fedora-workstation/issue/348 and RH internal https://issues.redhat.com/browse/DESKTOP-738.