### PR TITLE
Include pkcs11-provider in ELN

### DIFF
--- a/configs/sst_security_crypto-pkcs11.yaml
+++ b/configs/sst_security_crypto-pkcs11.yaml
@@ -1,0 +1,11 @@
+---
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: PKCS#11 support
+  description: Components providing access to PKCS#11 cryptographic tokens.
+  maintainer: sst_security_crypto
+  packages:
+    - pkcs11-provider
+  labels:
+    - eln


### PR DESCRIPTION
OpenSSL 3.x deprecated the ENGINE API, so add pkcs11-provider for modern OpenSSL PKCS#11 support.