### PR TITLE
kdump: add libkdumpfile and drgn

### DIFF
--- a/configs/sst_kernel_debug-kdump.yaml
+++ b/configs/sst_kernel_debug-kdump.yaml
@@ -13,6 +13,8 @@ data:
   - crash
   - snappy
   - crash-trace-command
+  - libkdumpfile
+  - drgn
     # Read ftrace data from a core dump file.
 
   arch_packages:


### PR DESCRIPTION
Add drgn to kdump as a new tool for vmcore analysis, also add libkdumpfile, which is needed by drgn.