### PR TITLE
Add git-email to the ELN Extras workload for Meta

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -34,6 +34,7 @@ data:
   - iotools
   - fd-find
   - fping
+  - git-email
   - glslang
   - hyperfine
   - keyrings-filesystem


### PR DESCRIPTION
Looks like this has been dropped but we need it for `git-send-email`.