### PR TITLE
sst_networking_core: add wpa_supplicant

### DIFF
--- a/configs/sst_networking_core-hostapd.yaml
+++ b/configs/sst_networking_core-hostapd.yaml
@@ -2,10 +2,11 @@ document: feedback-pipeline-workload
 version: 1
 data:
   name: hostapd
-  description: IEEE 802.11 AP, IEEE 802.1X/WPA/WPA2/EAP/RADIUS Authenticator
+  description: IEEE 802.11 AP, IEEE 802.1X/WPA/WPA2/EAP/RADIUS Authenticators
   maintainer: sst_networking_core
   packages:
   - hostapd
+  - wpa_supplicant
 
   labels:
   - eln


### PR DESCRIPTION
sst networking core owns wpa_supplicant. So lets mention it here so that it gets properly assigned to us.