### PR TITLE
Add ELN Extras workload for FAS account music

### DIFF
--- a/configs/eln_extras_music.yaml
+++ b/configs/eln_extras_music.yaml
@@ -1,0 +1,12 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: music packages
+  description: ELN Extras packages maintained by Ben Beasley
+  maintainer: music
+
+  packages:
+  - gi-docgen
+
+  labels:
+  - eln-extras


### PR DESCRIPTION
Currently, this includes only the `gi-docgen` package.