### PR TITLE
edge: Add bootupd

### DIFF
--- a/configs/sst_edge.yaml
+++ b/configs/sst_edge.yaml
@@ -35,6 +35,7 @@ data:
     - fdo-rendezvous-server
     - greenboot
     - greenboot-default-health-checks
+    - bootupd
     x86_64:
     - clevis-pin-tpm2
     - fdo-client
@@ -45,9 +46,11 @@ data:
     - fdo-rendezvous-server
     - greenboot
     - greenboot-default-health-checks
+    - bootupd
     ppc64le:
     - greenboot
     - greenboot-default-health-checks
+    - bootupd
 
   labels:
   - eln


### PR DESCRIPTION
So right now the "coreos" workload is disabled in ELN: https://github.com/minimization/content-resolver-input/blob/2331fc87220bebfe32dc5db5ec038c3948197e46/configs/sst_coreos.yaml#L35

In practice it seems like everything ended up here under edge.

Of tier 0, just missing bootupd, but we want to ship that in Edge.