### PR TITLE
Replace Cheese with Snapshot as the default webcam application in RHEL

### DIFF
--- a/configs/sst_desktop-snapshot.yaml
+++ b/configs/sst_desktop-snapshot.yaml
@@ -1,16 +1,12 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: Cheese
+  name: Snapshot
   description: Default application for handling webcams in Workstation
   maintainer: sst_desktop
 
   packages:
-  - clutter
-  - clutter-gtk
-  - clutter-gst3
-  - cogl
-  - cheese
+  - snapshot
 
   labels:
-  - c9s
+  - eln


### PR DESCRIPTION
Fedora Workstation will make a switch in F40, see
https://pagure.io/fedora-workstation/issue/166 and RH internal https://issues.redhat.com/browse/DESKTOP-739