### PR TITLE
libb2 is unwanted in ELN, blake2 hashes are available in libgcrypt and openssl

### DIFF
--- a/configs/sst_program-unwanted.yaml
+++ b/configs/sst_program-unwanted.yaml
@@ -50,6 +50,7 @@ data:
     - koji-utils
     - koji-vm
     - koji-web
+    - libb2
     - pandoc
     - python3-koji
     - python3-koji-cli-plugins


### PR DESCRIPTION

Fixes: #983