### PR TITLE
sst_coreos: fix typo

### DIFF
--- a/configs/sst_coreos.yaml
+++ b/configs/sst_coreos.yaml
@@ -9,7 +9,7 @@ data:
 
   packages:
   - afterburn
-  - afterburn-darcut
+  - afterburn-dracut
   - butane
   - console-login-helper-messages-issuegen
   - console-login-helper-messages-motdgen


### PR DESCRIPTION
Apparently this has been an issue in c9s for a while, but it came to ELN via #987.

/cc @cgwalters
