### PR TITLE
Explicitly require wsdd for Web Service Discovery in GNOME

### DIFF
--- a/configs/sst_desktop_applications-nautilus-eln.yaml
+++ b/configs/sst_desktop_applications-nautilus-eln.yaml
@@ -16,6 +16,7 @@ data:
   - libmtp
   - nautilus
   - sushi
+  - wsdd
 
   labels:
-  - c9s
+  - eln


### PR DESCRIPTION
This will result in Windows shares to be available in GNOME. Please see https://gitlab.gnome.org/GNOME/gvfs/-/merge_requests/186 and internal to Red Hat https://issues.redhat.com/browse/DESKTOP-564 for more information.