### PR TITLE
Remove Glade workload and mark it as unwanted

### DIFF
--- a/configs/sst_desktop-glade.yaml
+++ b/configs/sst_desktop-glade.yaml
@@ -9,5 +9,4 @@ data:
   - glade
 
   labels:
-  - eln
   - c9s

--- a/configs/sst_desktop-unwanted-eln.yaml
+++ b/configs/sst_desktop-unwanted-eln.yaml
@@ -95,5 +95,7 @@ data:
   # Replaced by tecla
   - libgnomekbd
   - libxklavier
+  # Obsoleted upstream for nearly 10 years
+  - glade
   labels:
   - eln


### PR DESCRIPTION
Obsolete upstream for nearly 10 years and UI files are supposed to be written by hand. Relevant blog
https://blogs.gnome.org/christopherdavis/2020/11/19/glade-not-recommended/

This is currently required by GTK based Anaconda. For more information please see RH internal https://issues.redhat.com/browse/DESKTOP-752