### PR TITLE
sst_coreos: bootupd is x86_64/aarch64 only

### DIFF
--- a/configs/sst_coreos.yaml
+++ b/configs/sst_coreos.yaml
@@ -31,8 +31,6 @@ data:
     - bootupd
     aarch64:
     - bootupd
-    ppc64le:
-    - bootupd
 
   labels:
   - eln


### PR DESCRIPTION
Based on the upstream documentation, bootupd is not supported on ppc64le, and is not built therefor in either Fedora or c9s.

/cc @cgwalters
