### PR TITLE
Add marshalparser to Python devel (CRB)

### DIFF
--- a/configs/sst_cs_apps-python-crb.yaml
+++ b/configs/sst_cs_apps-python-crb.yaml
@@ -24,6 +24,7 @@ data:
   - python3-psutil-tests
   - py3c-devel
   - py3c-doc
+  - marshalparser
   # the following packages are anticipated to be used by pyproject-rpm-macros
   # in the feature, so we want them in CRB early,
   # rather than going trough a tad tedious process to add them after GA


### PR DESCRIPTION
This package was included in RHEL 9 CRB via https://bugzilla.redhat.com/2051483

We want to keep it in CRB.