### PR TITLE
Mark Inkscape as unwanted

### DIFF
--- a/configs/sst_desktop_applications-unwanted-eln.yaml
+++ b/configs/sst_desktop_applications-unwanted-eln.yaml
@@ -101,6 +101,8 @@ data:
   # Thunderbird is the only shipped desktop email client in RHEL 10
   # evolution-data-server stays as it's needed by GNOME
   - evolution
+  # Vector graphic editor isn't supposed to be a built in functionality in the OS.
+  - inkscape
 
   labels:
   - eln


### PR DESCRIPTION
Removing the workload for ELN wasn't enough as some packages (such as djvulibre of python-matplotlib) are pulling it through build requires.