### PR TITLE
Fix the ELN Extras workload for Meta

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -29,7 +29,7 @@ data:
   - duo_unix-selinux
   - ebranch
   - et
-  - exa
+  - eza
   - htop
   - iotools
   - fd-find
@@ -95,14 +95,11 @@ data:
 
   arch_packages:
     aarch64:
-      - awscli2
       - sedutil
       - sysbench
     ppc64le:
-      - awscli2
       - sedutil
     x86_64:
-      - awscli2
       - msr-tools
       - sedutil
       - sysbench


### PR DESCRIPTION
- drop awscli2 now that it's included in ELN proper (https://github.com/minimization/content-resolver-input/commit/283d96b7a7bad87821dcc1f47054485775cfbb2)
- exa is gone, replace it with eza