### PR TITLE
bootc: New sst

### DIFF
--- a/configs/sst_bootc-eln.yaml
+++ b/configs/sst_bootc-eln.yaml
@@ -1,0 +1,14 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: bootc
+  description: >
+    OS compontents for bootc based systems for ELN.
+  maintainer: sst_bootc
+
+  packages:
+  - bootc
+
+  labels:
+  - c10s
+  - eln


### PR DESCRIPTION

The subsystem is new and the package is
just built in fedora, xref https://bugzilla.redhat.com/show_bug.cgi?id=2243345

Signed-off-by: Colin Walters <walters@verbum.org>

---

