### PR TITLE
Update fonts workload against f39

### DIFF
--- a/configs/sst_i18n-extra-fonts-eln.yaml
+++ b/configs/sst_i18n-extra-fonts-eln.yaml
@@ -10,18 +10,66 @@ data:
   - dejavu-lgc-sans-fonts
   - dejavu-lgc-sans-mono-fonts
   - dejavu-lgc-serif-fonts
+  - dejavu-sans-fonts
+  - dejavu-sans-mono-fonts
+  - dejavu-serif-fonts
   - google-carlito-fonts
   - google-crosextra-caladea-fonts
-  - google-noto-serif-armenian-vf-fonts
-  - google-noto-serif-cjk-vf-fonts
-  - google-noto-serif-georgian-vf-fonts
-  - google-noto-serif-hebrew-vf-fonts
-  - google-noto-serif-khmer-vf-fonts
-  - google-noto-serif-lao-vf-fonts
-  - google-noto-serif-sinhala-vf-fonts
-  - google-noto-serif-thai-vf-fonts
   - google-roboto-slab-fonts
   - julietaula-montserrat-fonts
+  - langpacks-fonts-am
+  - langpacks-fonts-ar
+  - langpacks-fonts-as
+  - langpacks-fonts-ast
+  - langpacks-fonts-be
+  - langpacks-fonts-bg
+  - langpacks-fonts-bn
+  - langpacks-fonts-bo
+  - langpacks-fonts-br
+  - langpacks-fonts-chr
+  - langpacks-fonts-dv
+  - langpacks-fonts-dz
+  - langpacks-fonts-el
+  - langpacks-fonts-eo
+  - langpacks-fonts-eu
+  - langpacks-fonts-fa
+  - langpacks-fonts-gu
+  - langpacks-fonts-he
+  - langpacks-fonts-hi
+  - langpacks-fonts-hy
+  - langpacks-fonts-ia
+  - langpacks-fonts-iu
+  - langpacks-fonts-ka
+  - langpacks-fonts-km
+  - langpacks-fonts-kn
+  - langpacks-fonts-ku
+  - langpacks-fonts-lo
+  - langpacks-fonts-mai
+  - langpacks-fonts-ml
+  - langpacks-fonts-mr
+  - langpacks-fonts-my
+  - langpacks-fonts-nb
+  - langpacks-fonts-ne
+  - langpacks-fonts-nn
+  - langpacks-fonts-nr
+  - langpacks-fonts-nso
+  - langpacks-fonts-or
+  - langpacks-fonts-pa
+  - langpacks-fonts-ru
+  - langpacks-fonts-si
+  - langpacks-fonts-ss
+  - langpacks-fonts-ta
+  - langpacks-fonts-te
+  - langpacks-fonts-th
+  - langpacks-fonts-tn
+  - langpacks-fonts-ts
+  - langpacks-fonts-uk
+  - langpacks-fonts-ur
+  - langpacks-fonts-ve
+  - langpacks-fonts-vi
+  - langpacks-fonts-xh
+  - langpacks-fonts-yi
+  - langpacks-fonts-zu
   - lato-fonts
   - liberation-narrow-fonts
   - open-sans-fonts
@@ -29,7 +77,6 @@ data:
   - redhat-display-fonts
   - redhat-mono-fonts
   - redhat-text-fonts
-  - rit-rachana-fonts
 
   labels:
   - eln

--- a/configs/sst_i18n-fonts-eln.yaml
+++ b/configs/sst_i18n-fonts-eln.yaml
@@ -6,55 +6,76 @@ data:
   maintainer: sst_i18n
 
   packages:
-  - abattis-cantarell-vf-fonts
   - adobe-source-code-pro-fonts
-  - dejavu-sans-fonts
-  - dejavu-sans-mono-fonts
-  - dejavu-serif-fonts
-  - google-noto-color-emoji-fonts
-  - google-noto-naskh-arabic-vf-fonts
-  - google-noto-sans-arabic-vf-fonts
-  - google-noto-sans-armenian-vf-fonts
-  - google-noto-sans-canadian-aboriginal-vf-fonts
-  - google-noto-sans-cherokee-vf-fonts
-  - google-noto-sans-cjk-vf-fonts
-  - google-noto-sans-ethiopic-vf-fonts
-  - google-noto-sans-georgian-vf-fonts
-  - google-noto-sans-gurmukhi-vf-fonts
-  - google-noto-sans-hebrew-vf-fonts
-  - google-noto-sans-khmer-vf-fonts
-  - google-noto-sans-lao-vf-fonts
-  - google-noto-sans-math-fonts
-  - google-noto-sans-mono-vf-fonts
-  - google-noto-sans-sinhala-vf-fonts
-  - google-noto-sans-symbols-vf-fonts
-  - google-noto-sans-symbols2-fonts
-  - google-noto-sans-thaana-vf-fonts
-  - google-noto-sans-thai-vf-fonts
-  - google-noto-sans-vf-fonts
-  - google-noto-serif-vf-fonts
-  - jomolhari-fonts
+  - default-fonts-am
+  - default-fonts-ar
+  - default-fonts-as
+  - default-fonts-ast
+  - default-fonts-be
+  - default-fonts-bg
+  - default-fonts-bn
+  - default-fonts-bo
+  - default-fonts-br
+  - default-fonts-chr
+  - default-fonts-cjk-mono
+  - default-fonts-cjk-sans
+  - default-fonts-cjk-serif
+  - default-fonts-core-emoji
+  - default-fonts-core-math
+  - default-fonts-core-mono
+  - default-fonts-core-sans
+  - default-fonts-core-serif
+  - default-fonts-dv
+  - default-fonts-dz
+  - default-fonts-el
+  - default-fonts-eo
+  - default-fonts-eu
+  - default-fonts-fa
+  - default-fonts-gu
+  - default-fonts-he
+  - default-fonts-hi
+  - default-fonts-hy
+  - default-fonts-ia
+  - default-fonts-iu
+  - default-fonts-ka
+  - default-fonts-km
+  - default-fonts-kn
+  - default-fonts-ku
+  - default-fonts-lo
+  - default-fonts-mai
+  - default-fonts-ml
+  - default-fonts-mr
+  - default-fonts-my
+  - default-fonts-nb
+  - default-fonts-ne
+  - default-fonts-nn
+  - default-fonts-nr
+  - default-fonts-nso
+  - default-fonts-or
+  - default-fonts-other-mono
+  - default-fonts-other-sans
+  - default-fonts-other-serif
+  - default-fonts-pa
+  - default-fonts-ru
+  - default-fonts-si
+  - default-fonts-ss
+  - default-fonts-ta
+  - default-fonts-te
+  - default-fonts-th
+  - default-fonts-tn
+  - default-fonts-ts
+  - default-fonts-uk
+  - default-fonts-ur
+  - default-fonts-ve
+  - default-fonts-vi
+  - default-fonts-xh
+  - default-fonts-yi
+  - default-fonts-zu
   - liberation-mono-fonts
   - liberation-sans-fonts
   - liberation-serif-fonts
-  - lohit-assamese-fonts
-  - lohit-bengali-fonts
-  - lohit-devanagari-fonts
-  - lohit-gujarati-fonts
-  - lohit-kannada-fonts
-  - lohit-marathi-fonts
-  - lohit-odia-fonts
-  - lohit-tamil-fonts
-  - lohit-telugu-fonts
-  - madan-fonts
-  - paktype-naskh-basic-fonts
   - pt-sans-fonts
-  - rit-meera-new-fonts
   - sil-mingzat-fonts
-  - sil-nuosu-fonts
-  - sil-padauk-fonts
-  - stix-fonts
-  - vazirmatn-vf-fonts
 
   labels:
   - eln


### PR DESCRIPTION
The main change in this is to add langpacks font-related meta packages such as default-fonts* and sort out a bit between -fonts and -extra-fonts.