### PR TITLE
Mark motif as an unwanted package

### DIFF
--- a/configs/sst_gpu-X11-enviroment-c9s.yaml
+++ b/configs/sst_gpu-X11-enviroment-c9s.yaml
@@ -12,5 +12,4 @@ data:
     - xrestop
 
   labels:
-    - eln
     - c9s

--- a/configs/sst_gpu-X11-enviroment-eln.yaml
+++ b/configs/sst_gpu-X11-enviroment-eln.yaml
@@ -1,0 +1,14 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Traditional X11 environment
+  description: Libraries and sample applications historically provided with an X11 installation
+  maintainer: sst_gpu
+
+  packages:
+    - libXaw
+    - mesa-libGLU
+    - xrestop
+
+  labels:
+    - eln

--- a/configs/sst_gpu-unwanted-c9s.yaml
+++ b/configs/sst_gpu-unwanted-c9s.yaml
@@ -1,0 +1,48 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: GPU - Blocked packages
+  description: GPU - Packages which should not be in RHEL 9
+  maintainer: sst_gpu
+  unwanted_packages:
+  # only used by mesa-demos, but that’s likely to change, see https://gitlab.freedesktop.org/mesa/demos/-/merge_requests/23
+  - glew
+  # HFS+ is not supported in RHEL - not currently packaged in RHEL 8, just adding in case dependencies try to pull it in
+  - hfsplus-tools
+  # Seems to only be used by hwloc in an optional plugin
+  - libXNVCtrl
+  # Not very used and the only consumer of xorg-sgml-doctools
+  - xorg-x11-docs
+  # Remove in favor of the modessting drivers for ati, intel and nouveau
+  - xorg-x11-drv-intel
+  - xorg-x11-drv-nouveau
+  - xorg-x11-drv-ati
+  # Remove as its provides quite a bad user experience and we can avoid to maintain vesa
+  - xorg-x11-drv-vesa
+  # Replaced by tools in libinput
+  - evemu
+  # Not maintained upstream, very ancient tool, and don't have resoures to maintain an extra GUI toolkit and window manager
+  # - motif asamalik: it's ACG 1, so we need to keep it now
+  # BR for rubygem-clutter-gstreamer. Said rubygem shouldn't be in EL9. Also, superseeded by clutter-gst3.
+  - clutter-gst2
+  # Virtually unused even in Fedora, might have been used by spice once upon a time. Also, superseeded by opus.
+  - celt051
+  # Ancient build system, with low upstream maintenance.
+  - imake
+  # Only used by optional plugin of hwloc, removed for RHEL.
+  - libXNVCtrl
+  # Only used for some old games and emulators
+  - SFML
+  # Only used by some multimedia apps we don't ship
+  - libmpcdec
+  # Seems unused
+  - libsamplerate
+  # It should go
+  - libxml++
+  # Only used by openal-soft examples, brings in other unwanted deps
+  - SDL_sound
+  # glew is no longer needed by mesa-demos, and the soname churns too much to be
+  # useful for a long-life product like RHEL.
+  - glew
+  labels:
+  - c9s

--- a/configs/sst_gpu-unwanted-eln.yaml
+++ b/configs/sst_gpu-unwanted-eln.yaml
@@ -1,8 +1,8 @@
 document: feedback-pipeline-unwanted
 version: 1
 data:
-  name: Graphics Infrastructure - Blocked packages
-  description: Graphics Infrastructure - Packages which should not be in ELN
+  name: GPU - Blocked packages
+  description: GPU - Packages which should not be in ELN
   maintainer: sst_gpu
   unwanted_packages:
   # only used by mesa-demos, but that’s likely to change, see https://gitlab.freedesktop.org/mesa/demos/-/merge_requests/23
@@ -31,6 +31,8 @@ data:
   - imake
   # Only used by optional plugin of hwloc, removed for RHEL.
   - libXNVCtrl
+  # Deprecated since RHEL 9 (technically even 8.4), removed in RHEL 10
+  - motif
   # Only used for some old games and emulators
   - SFML
   # Only used by some multimedia apps we don't ship
@@ -46,4 +48,3 @@ data:
   - glew
   labels:
   - eln
-  - c9s


### PR DESCRIPTION
Motif has been deprecated in RHEL 9 (see [1] and [2]) and technically even already in the RHEL 8 lifecycle (see [3]), and we're now removing this in RHEL 10.

See also Red Hat internal tracking ticket
https://issues.redhat.com/browse/GPU-621

[1]: https://access.redhat.com/solutions/6113101
[2]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.0_release_notes/deprecated_functionality#JIRA-RHELPLAN-98983
[3]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.5_release_notes/deprecated_functionality#JIRA-RHELPLAN-98983