### PR TITLE
Remove Devhelp from RHEL 10

### DIFF
--- a/configs/sst_desktop_applications-devhelp.yaml
+++ b/configs/sst_desktop_applications-devhelp.yaml
@@ -9,5 +9,4 @@ data:
   - devhelp
 
   labels:
-  - eln
   - c9s


### PR DESCRIPTION
Devhelp is based on WebKitGTK that won't be in RHEL 10 and the documentation for various librariescan be found online if needed, e.g. in https://developer.gnome.org/documentation/introduction/overview/libraries.html

See internal to Red Hat https://issues.redhat.com/browse/DESKTOP-800 for more information.