### PR TITLE
Temporarily remove evolution-ews from ELN

### DIFF
--- a/configs/sst_desktop_applications-evolution-data-server.yaml
+++ b/configs/sst_desktop_applications-evolution-data-server.yaml
@@ -8,8 +8,13 @@ data:
   packages:
   - evolution-data-server
   - evolution-data-server-langpacks
-  - evolution-ews
-  - evolution-ews-langpacks
+  # Temporarily disable EWS as it pulls in the whole Evolution (and
+  # thus WebKitGTK that will be removed from RHEL 10). We will look
+  # whether EWS could be reworked so it doesn't require it and then
+  # we will reenable this or if we fail, then we will remove it
+  # altogether.
+  # - evolution-ews
+  # - evolution-ews-langpacks
 
   labels:
   - eln


### PR DESCRIPTION
Temporarily disable EWS as it pulls in the whole Evolution (and thus WebKitGTK that will be removed from RHEL 10). We will look whether EWS could be reworked so it doesn't require it and then we will reenable this or if we fail, then we will remove it altogether