### PR TITLE
Move Thunderbird and Firefox from ELN to ELN Extras

### DIFF
--- a/configs/sst_desktop_applications-firefox.yaml
+++ b/configs/sst_desktop_applications-firefox.yaml
@@ -9,5 +9,10 @@ data:
   - firefox
 
   labels:
-  - eln
-  - c9s
+  # This package is only in ELN Extras because in RHEL we're using a different
+  # packaging than in Fedora (and in fact in RHEL 10 this will be shipped in
+  # Flatpak only), and this package pulls things into regular ELN which won't
+  # be needed in RHEL. On the other hand, we're still interested in knowing
+  # how this package works with all the extra ELN bits such as extra hardening
+  # flags and others and apparently that's what eln-extras is for.
+  - eln-extras

--- a/configs/sst_desktop_applications-thunderbird.yaml
+++ b/configs/sst_desktop_applications-thunderbird.yaml
@@ -9,5 +9,10 @@ data:
   - thunderbird
 
   labels:
-  - eln
-  - c9s
+  # This package is only in ELN Extras because in RHEL we're using a different
+  # packaging than in Fedora (and in fact in RHEL 10 this will be shipped in
+  # Flatpak only), and this package pulls things into regular ELN which won't
+  # be needed in RHEL. On the other hand, we're still interested in knowing
+  # how this package works with all the extra ELN bits such as extra hardening
+  # flags and others and apparently that's what eln-extras is for.
+  - eln-extras


### PR DESCRIPTION
We're using different packaging in RHEL (and in RHEL 10 those will be shipped as Flatpaks only) than in Fedora so the dependencies are not the same and the ELN is being "polluted" by packages that won't be needed in RHEL at all. On the other hand we're still interested in knowing how Thundebird and Firefox comply with all the ELN specific changes (extra hardening flags, ..) so ELN Extras is better place for these.