### PR TITLE
bootc: Add composefs to c10s/eln

### DIFF
--- a/configs/sst_bootc-eln.yaml
+++ b/configs/sst_bootc-eln.yaml
@@ -8,6 +8,7 @@ data:
 
   packages:
   - bootc
+  - composefs
 
   labels:
   - c10s


### PR DESCRIPTION
ostree and podman are going to centralize on this as a key underlying technology.