### PR TITLE
Add vulkan-utility-libraries

### DIFF
--- a/configs/sst_gpu-GPU-drivers.yaml
+++ b/configs/sst_gpu-GPU-drivers.yaml
@@ -11,6 +11,7 @@ data:
     - mesa-vulkan-drivers
     - mesa-libEGL
     - libglvnd
+    - vulkan-utility-libraries
     - vulkan-validation-layers
     - vulkan-headers
     - vulkan-tools


### PR DESCRIPTION
The vulkan-utility-libraries package is required to build the Vulkan SDK (v1.3.268.0).

For more information please check:
https://github.com/KhronosGroup/Vulkan-Utility-Libraries#readme

JIRA issue: https://issues.redhat.com/browse/RHEL-15445
Fedora: https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=2247640