### PR TITLE
Add libtiff, libpng to apps images workload.

### DIFF
--- a/configs/sst_cs_apps-images.yaml
+++ b/configs/sst_cs_apps-images.yaml
@@ -6,7 +6,9 @@ data:
   maintainer: sst_cs_apps
 
   packages:
+  - libpng
   - libpng-devel
+  - libtiff
   - libtiff-devel
 
   labels:


### PR DESCRIPTION
For review by @hhorak

`libtiff` & `libpng` are both owned by sst_cs_apps in RHEL and ship in AppStream/BaseOS but the workload only lists the `-devel` subpackages, is that deliberate or is it an oversight?