### PR TITLE
Add vulkan-utility-libraries-devel

### DIFF
--- a/configs/sst_gpu-GPU-drivers.yaml
+++ b/configs/sst_gpu-GPU-drivers.yaml
@@ -11,7 +11,7 @@ data:
     - mesa-vulkan-drivers
     - mesa-libEGL
     - libglvnd
-    - vulkan-utility-libraries
+    - vulkan-utility-libraries-devel
     - vulkan-validation-layers
     - vulkan-headers
     - vulkan-tools


### PR DESCRIPTION
The vulkan-utility-libraries package only contains headers and a static library, therefore, only its -devel version is generated.

Replace vulkan-utility-libraries with its -devel variant.

JIRA issue: https://issues.redhat.com/browse/RHEL-15445
Fedora: https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=2247640
Fixes: 5754e8966613 ("Add vulkan-utility-libraries")