### PR TITLE
Remove `numad` and `pinfo` from ELN

### DIFF
--- a/configs/sst_cs_plumbers-cli-tools.yaml
+++ b/configs/sst_cs_plumbers-cli-tools.yaml
@@ -6,7 +6,6 @@ data:
   maintainer: sst_cs_plumbers
 
   packages:
-  - pinfo
   - usbutils
   - mlocate
   - mtr

--- a/configs/sst_cs_plumbers-hw-tools-c9s.yaml
+++ b/configs/sst_cs_plumbers-hw-tools-c9s.yaml
@@ -9,6 +9,7 @@ data:
   # asamalik: Moving biosdevname to x86 architectures only as it's not available elsewhere
   #- biosdevname
   - ledmon
+  - numad
   - sgpio
   - libatasmart
   
@@ -28,4 +29,4 @@ data:
       - systemd-devel
 
   labels:
-  - eln
+  - c9s

--- a/configs/sst_cs_plumbers-unwanted-c9s.yaml
+++ b/configs/sst_cs_plumbers-unwanted-c9s.yaml
@@ -2,7 +2,7 @@ document: feedback-pipeline-unwanted
 version: 1
 data:
   name: Core Services Plumbers - Blocked packages
-  description: Core Services Plumbers - Packages which should not be in ELN
+  description: Core Services Plumbers - Packages which should not be in C9S
   maintainer: sst_cs_plumbers
 
   unwanted_packages:
@@ -24,7 +24,6 @@ data:
   - libtar
   - libtar-devel
   - network-scripts
-  - numad
   - python3-bottle
   - redhat-lsb
   - redhat-lsb-core
@@ -41,4 +40,4 @@ data:
   - vorbis-tools
 
   labels:
-  - eln
+  - c9s

--- a/configs/sst_cs_plumbers-unwanted.yaml
+++ b/configs/sst_cs_plumbers-unwanted.yaml
@@ -25,6 +25,7 @@ data:
   - libtar-devel
   - network-scripts
   - numad
+  - pinfo
   - python3-bottle
   - redhat-lsb
   - redhat-lsb-core


### PR DESCRIPTION
The plan is to provide these packages in EPEL 10 instead.

\cc @lnykryn