### PR TITLE
s390utils is available for all arches

### DIFF
--- a/configs/sst_arch_hw.yaml
+++ b/configs/sst_arch_hw.yaml
@@ -28,6 +28,7 @@ data:
   - hwloc
   - pigz
   - ethtool
+  - s390utils
 
   arch_packages:
     ppc64le:
@@ -51,7 +52,6 @@ data:
     - libzpc
     - libzpc-devel
     - openssl-ibmca
-    - s390utils
     - s390utils-base
     - s390utils-chreipl-fcp-mpath
     - s390utils-cmsfs-fuse


### PR DESCRIPTION
Some of the tools from the s390utils source package are now built for all platforms, thus move the s390utils entry from the s390x section to the general one.

Related: https://issues.redhat.com/browse/RHEL-10567