### PR TITLE
Ignore java-*-openjdk-portable in ELN

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -96,7 +96,7 @@ data:
         baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
+        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery", "java-*-openjdk-portable*"]
         priority: 5
       
     releasever: "rawhide"


### PR DESCRIPTION
java-openjdk-portable packages are built differently internally and therefore not intended to be imported into the next RHEL version.  With Fedora's build now using pandoc, which is unwanted in RHEL due to its GHC dependencies, to build documentation, we need to ignore it entirely.

/cc @asamalik 