### PR TITLE
Ignore java-*-openjdk-portable in ELN buildroot too

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -89,7 +89,7 @@ data:
         baseurl: https://kojipkgs.fedoraproject.org/repos/eln-build/latest/$basearch/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
+        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery", "java-*-openjdk-portable*"]
         priority: 4
       
       Rawhide:


### PR DESCRIPTION
Ignoring it from the Rawhide repo was insufficient.

This is a follow-up to #1030.

/cc @asamalik @sgallagher
