### PR TITLE
Add GNOME Clocks in RHEL 10

### DIFF
--- a/configs/sst_desktop-gnome-clocks.yaml
+++ b/configs/sst_desktop-gnome-clocks.yaml
@@ -1,0 +1,12 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: GNOME Clocks
+  description: Clocks application for Workstation
+  maintainer: sst_desktop
+
+  packages:
+  - gnome-clocks
+
+  labels:
+  - eln


### PR DESCRIPTION
Without it it's impossible to add alternative time zones in GNOME.

See https://issues.redhat.com/browse/RHEL-4230