### PR TITLE
Remove TigerVNC from RHEL 10

### DIFF
--- a/configs/sst_desktop_applications-tigervnc.yaml
+++ b/configs/sst_desktop_applications-tigervnc.yaml
@@ -12,5 +12,4 @@ data:
   - tigervnc-server-module
 
   labels:
-  - eln
   - c9s


### PR DESCRIPTION
As announced in [0] the Xorg server will be removed from RHEL 10 which we will take as the opportunity to remove TigerVNC from RHEL 10 as well and suggest to use RDP protocol through GNOME Remote Desktop instead (that relies on FreeRDP[2] project). As of now Xorg server source files are not planned to be shipped in RHEL 10 so technically we won't be able to build TigerVNC in RHEL 10 anyway.

With TigerVNC removal the server and client will be removed, but the ability to connect to other VNC servers (running for example on older RHEL versions) will remain through GNOME Connections[3] which is already shipped in RHEL 9.

[0] - https://www.redhat.com/en/blog/rhel-10-plans-wayland-and-xorg-server
[1] - https://gitlab.gnome.org/GNOME/gnome-remote-desktop
[2] - https://github.com/FreeRDP/FreeRDP/
[3] - https://gitlab.gnome.org/GNOME/connections/