### PR TITLE
sst_desktop: libsoup3 is wanted in ELN, not libsoup

### DIFF
--- a/configs/sst_desktop-gnome-desktop-eln.yaml
+++ b/configs/sst_desktop-gnome-desktop-eln.yaml
@@ -32,7 +32,7 @@ data:
   - gnome-browser-connector
   - libgweather4
   - libproxy
-  - libsoup
+  - libsoup3
   - tecla
   - tracker
   - tracker-miners


### PR DESCRIPTION
libsoup is explictly unwanted in ELN, having been replaced by libsoup3.

/cc @tpopela
