### PR TITLE
Drop (temporarily) Yelp from ELN/RHEL 10

### DIFF
--- a/configs/sst_desktop-yelp.yaml
+++ b/configs/sst_desktop-yelp.yaml
@@ -9,5 +9,4 @@ data:
   - yelp
 
   labels:
-  - eln
   - c9s


### PR DESCRIPTION
We're removing WebKitGTK[[0] from RHEL 10 and one of the applications that are using it is Yelp which is the default help viewer in GNOME[1]. We do have some plans[2] on how to rework the whole thing so the existing help is diplayed in the default browser. But until we agree on something (and implement it) we shouldn't block the WebKitGTK removal and rather temporarily remove it. It used to be required by Anaconda as well, but the dependency was dropped with [3] which is part of the ELN [4].

[0] - https://issues.redhat.com/browse/DESKTOP-670
[1] - https://issues.redhat.com/browse/DESKTOP-679
[2] - https://gitlab.gnome.org/GNOME/yelp-tools/-/merge_requests/12
[3] - https://github.com/rhinstaller/anaconda/pull/5335
[4] - https://koji.fedoraproject.org/koji/buildinfo?buildID=2325587