### PR TITLE
Add gstreamer1-rtsp-server

### DIFF
--- a/configs/sst_gpu-multimedia-libraries.yaml
+++ b/configs/sst_gpu-multimedia-libraries.yaml
@@ -11,6 +11,7 @@ data:
     - gstreamer1-plugins-good
     - gstreamer1-plugins-bad-free
     - gstreamer1-plugins-ugly-free
+    - gstreamer1-rtsp-server
     # Used for preview of camera images as plugin for pixbuf in Files
     - libopenraw
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2186498 for the original reason we pulled in this package into RHEL 9, which probably won't go away when we launch RHEL 10.