### PR TITLE
C9S,C10S: Introduce the new subpackages from cups-filters

### DIFF
--- a/configs/sst_cs_infra_services-printing-stack-c10s.yaml
+++ b/configs/sst_cs_infra_services-printing-stack-c10s.yaml
@@ -7,6 +7,7 @@ data:
 
   packages:
   - cups-browsed
+  - cups-filters-driverless
   - ipp-usb
   - libcupsfilters
   - libppd

--- a/configs/sst_cs_infra_services-printing-stack.yaml
+++ b/configs/sst_cs_infra_services-printing-stack.yaml
@@ -8,8 +8,10 @@ data:
   packages:
   # tools
   - cups
+  - cups-browsed
   - cups-client
   - cups-filters
+  - cups-filters-driverless
   - cups-ipptool
   - cups-lpd
   - cups-printerapp


### PR DESCRIPTION
The new subpackages were created in C8S, C9S, C10S and ELN, marked them as wanted for my stack.