### PR TITLE
Track the Mailman 3 stack in ELN Extras

### DIFF
--- a/configs/eln_extras_mailman3.yaml
+++ b/configs/eln_extras_mailman3.yaml
@@ -1,0 +1,14 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Mailman 3 eln-extra packages
+  description: Mailman 3 ELN Extras packages
+  maintainer: ngompa
+
+  packages:
+  - mailman3
+  - hyperkitty
+  - postorius
+
+  labels:
+  - eln-extras


### PR DESCRIPTION
This is an important application for Fedora Infrastructure and needs to be tracked to ensure it can be built for EPEL in the future.