### PR TITLE
Add Anaconda Initial Setup to ELN Extras

### DIFF
--- a/configs/eln_extras_initialsetup.yaml
+++ b/configs/eln_extras_initialsetup.yaml
@@ -1,0 +1,15 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: initial-setup eln-extra packages
+  description: Anaconda Initial Setup ELN Extras packages
+  maintainer: ngompa
+
+  packages:
+  - initial-setup
+  - initial-setup-gui
+  - initial-setup-gui-wayland-generic
+
+
+  labels:
+  - eln-extras


### PR DESCRIPTION
Various Enterprise Linux setups will want to be able to do this for things like spins/remixes or mass deployments.