### PR TITLE
ELN: enhance unwanted repository filtering

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -11,32 +11,27 @@ data:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
         priority: 1
       AppStream:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
         priority: 1
       CRB:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
         priority: 1
       HA:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/HighAvailability/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
         limit_arches: ["aarch64", "ppc64le", "s390x", "x86_64"]
         priority: 2
       NFV:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/NFV/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
         limit_arches: ["x86_64"]
         priority: 2
       RT:
@@ -44,46 +39,67 @@ data:
         priority: 50
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
         limit_arches: ["x86_64"]
       RS:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/ResilientStorage/$basearch/os/
         priority: 50
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
         limit_arches: ["ppc64le", "s390x", "x86_64"]
       SAP:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/SAP/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
         limit_arches: ["ppc64le", "s390x", "x86_64"]
         priority: 2
       SAPHANA:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/SAPHANA/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
         limit_arches: ["ppc64le", "x86_64"]
         priority: 2
       Extras:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/Extras/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
         priority: 3
       buildroot:
         baseurl: https://kojipkgs.fedoraproject.org/repos/eln-build/latest/$basearch/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery", "java-*-openjdk-portable*"]
+        exclude: &eln_excludes
+        # prefer bind
+        - bind9-next*
+        # prefer postfix and sendmail
+        - esmtp
+        - esmtp-local-delivery
+        - exim
+        - opensmtpd
+        # RHEL packages are named ipa*
+        - freeipa*
+        # openjdk-portable packages are built against the oldest supported
+        # RHEL version, will not be imported into next RHEL version
+        - java-*-openjdk-portable*
+        # pulls in GHC stack
+        - pandoc
+        # unwanted python deps
+        - python3-build
+        - python3-docs
+        - python3-hypothesis
+        - python3-ipython
+        - python3-pytest-cov
+        - python3-pytest-xdist
+        - python3-recommonmark
+        - python3-tox-current-env
+        - tox
+        # prefer grubby
+        - sdubby
         priority: 4
       Rawhide:
         baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery", "java-*-openjdk-portable*"]
+        exclude: *eln_excludes
         priority: 5
     releasever: "rawhide"
     architectures:


### PR DESCRIPTION
We do not need to filter exim, esmtp, etc. here because we use hints in fedora-release to choose postfix as the provider of smtpdaemon.  But we can use this filtering to block certain unwanted packages which are frequent culprits in pulling in hundreds or even a thousand-some more unwanted packages into ELN.