### PR TITLE
Add vulkan-volk-devel

### DIFF
--- a/configs/sst_gpu-GPU-drivers.yaml
+++ b/configs/sst_gpu-GPU-drivers.yaml
@@ -13,6 +13,7 @@ data:
     - libglvnd
     - vulkan-utility-libraries-devel
     - vulkan-validation-layers
+    - vulkan-volk-devel
     - vulkan-headers
     - vulkan-tools
     - vulkan-loader


### PR DESCRIPTION
The vulkan-volk package is required to build the Vulkan SDK (v1.3.272).

More precisely, it will be a build dependency of vulkan-tools.

JIRA issue: https://issues.redhat.com/browse/RHEL-21041
Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=2257275