### PR TITLE
Add efs-utils-selinux subpackage

### DIFF
--- a/configs/sst_cloud_experience.yaml
+++ b/configs/sst_cloud_experience.yaml
@@ -7,6 +7,7 @@ data:
 
   packages:
     - efs-utils
+    - efs-utils-selinux
     - python3-botocore
     - python3-prompt-toolkit
     - python3-ruamel-yaml


### PR DESCRIPTION
Once efs-utils was packaged, we realized that a SELinux policy subpackage would be required.