### PR TITLE
Mark http-parser unwanted in ELN

### DIFF
--- a/configs/sst_security_special_projects-unwanted.yaml
+++ b/configs/sst_security_special_projects-unwanted.yaml
@@ -1,0 +1,12 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Unwanted SST Security Special Projects packages
+  description: SST Security Special Projects unwanted packages
+  maintainer: sst_security_special_projects
+
+  unwanted_source_packages:
+  - http-parser
+
+  labels:
+  - eln


### PR DESCRIPTION
Previously maintained as a dependency of tang, it was also a dependency of libgit2.  http-parser is unmaintained upstream, and tang has been ported to llhttp.  libgit2 needs to do the same so that http-parser can be dropped from ELN, but this marks it unwanted in the meantime.

This is a follow-up to https://github.com/minimization/content-resolver-input/pull/1054

/cc @sergio-correia 
