### PR TITLE
c9s/eln: add uki-direct (new python3-virt-firmware sub-rpm)

### DIFF
--- a/configs/sst_virtualization-all-eln.yaml
+++ b/configs/sst_virtualization-all-eln.yaml
@@ -30,6 +30,7 @@ data:
   - python3-libvirt
   - python3-pefile
   - python3-virt-firmware
+  - uki-direct
   - vhostmd
   - virt-install
   - virt-viewer

--- a/configs/sst_virtualization-all.yaml
+++ b/configs/sst_virtualization-all.yaml
@@ -29,6 +29,7 @@ data:
   - python3-virt-firmware
   - spice-protocol
   - spice-vdagent
+  - uki-direct
   - vhostmd
   - virt-install
   - virt-viewer


### PR DESCRIPTION
Manages uefi boot configuration for UKIs.