### PR TITLE
Drop java-17-openjdk from ELN

### DIFF
--- a/configs/sst_java-java.yaml
+++ b/configs/sst_java-java.yaml
@@ -8,24 +8,24 @@ data:
   - eln
 
   packages:
-  - java-17-openjdk
-  - java-17-openjdk-demo
-  - java-17-openjdk-devel
-  - java-17-openjdk-headless
-  - java-17-openjdk-javadoc
-  - java-17-openjdk-javadoc-zip
-  - java-17-openjdk-jmods
-  - java-17-openjdk-src
-  - java-17-openjdk-static-libs
+  - java-21-openjdk
+  - java-21-openjdk-demo
+  - java-21-openjdk-devel
+  - java-21-openjdk-headless
+  - java-21-openjdk-javadoc
+  - java-21-openjdk-javadoc-zip
+  - java-21-openjdk-jmods
+  - java-21-openjdk-src
+  - java-21-openjdk-static-libs
   - copy-jdk-configs
   # Debug packages should be built but shipped in CRB
-  - java-17-openjdk-slowdebug
-  - java-17-openjdk-demo-slowdebug
-  - java-17-openjdk-devel-slowdebug
-  - java-17-openjdk-headless-slowdebug
-  - java-17-openjdk-jmods-slowdebug
-  - java-17-openjdk-src-slowdebug
-  - java-17-openjdk-static-libs-slowdebug
+  - java-21-openjdk-slowdebug
+  - java-21-openjdk-demo-slowdebug
+  - java-21-openjdk-devel-slowdebug
+  - java-21-openjdk-headless-slowdebug
+  - java-21-openjdk-jmods-slowdebug
+  - java-21-openjdk-src-slowdebug
+  - java-21-openjdk-static-libs-slowdebug
   # Core tool for JDK support work
   - byteman
   - byteman-bmunit
@@ -34,72 +34,26 @@ data:
   # no s390x fastdebug due to build times
   arch_packages:
     aarch64:
-    - java-17-openjdk-fastdebug
-    - java-17-openjdk-demo-fastdebug
-    - java-17-openjdk-devel-fastdebug
-    - java-17-openjdk-headless-fastdebug
-    - java-17-openjdk-jmods-fastdebug
-    - java-17-openjdk-src-fastdebug
-    - java-17-openjdk-static-libs-fastdebug
+    - java-21-openjdk-fastdebug
+    - java-21-openjdk-demo-fastdebug
+    - java-21-openjdk-devel-fastdebug
+    - java-21-openjdk-headless-fastdebug
+    - java-21-openjdk-jmods-fastdebug
+    - java-21-openjdk-src-fastdebug
+    - java-21-openjdk-static-libs-fastdebug
     ppc64le:
-    - java-17-openjdk-fastdebug
-    - java-17-openjdk-demo-fastdebug
-    - java-17-openjdk-devel-fastdebug
-    - java-17-openjdk-headless-fastdebug
-    - java-17-openjdk-jmods-fastdebug
-    - java-17-openjdk-src-fastdebug
-    - java-17-openjdk-static-libs-fastdebug
+    - java-21-openjdk-fastdebug
+    - java-21-openjdk-demo-fastdebug
+    - java-21-openjdk-devel-fastdebug
+    - java-21-openjdk-headless-fastdebug
+    - java-21-openjdk-jmods-fastdebug
+    - java-21-openjdk-src-fastdebug
+    - java-21-openjdk-static-libs-fastdebug
     x86_64:
-    - java-17-openjdk-fastdebug
-    - java-17-openjdk-demo-fastdebug
-    - java-17-openjdk-devel-fastdebug
-    - java-17-openjdk-headless-fastdebug
-    - java-17-openjdk-jmods-fastdebug
-    - java-17-openjdk-src-fastdebug
-    - java-17-openjdk-static-libs-fastdebug
-
-  package_placeholders:
-    java-21-openjdk:
-      srpm: java-21-openjdk
-      description: Future long-term supported release of OpenJDK
-      requires:
-        - fontconfig
-        - xorg-x11-fonts-Type1
-        - ca-certificates
-        - javapackages-filesystem
-        - tzdata-java
-        - copy-jdk-configs
-        - cups-libs
-      buildrequires:
-        - autoconf
-        - automake
-        - alsa-lib-devel
-        - binutils
-        - cups-devel
-        - desktop-file-utils
-        - elfutils-devel
-        - file
-        - fontconfig-devel
-        - gcc-c++
-        - gdb
-        - libX11-devel
-        - libXi-devel
-        - libXinerama-devel
-        - libXrandr-devel
-        - libXrender-devel
-        - libXt-devel
-        - libXtst-devel
-        - libxslt
-        - nss-devel
-        - pkgconfig
-        - xorg-x11-proto-devel
-        - zip
-        - tar
-        - unzip
-        - javapackages-filesystem
-        - libffi-devel
-        - tzdata-java
-        - ca-certificates
-        - gcc
-        - systemtap-sdt-devel
-        - make
+    - java-21-openjdk-fastdebug
+    - java-21-openjdk-demo-fastdebug
+    - java-21-openjdk-devel-fastdebug
+    - java-21-openjdk-headless-fastdebug
+    - java-21-openjdk-jmods-fastdebug
+    - java-21-openjdk-src-fastdebug
+    - java-21-openjdk-static-libs-fastdebug

--- a/configs/sst_java-unwanted.yaml
+++ b/configs/sst_java-unwanted.yaml
@@ -32,6 +32,15 @@ data:
   - java-11-openjdk-jmods
   - java-11-openjdk-src
   - java-11-openjdk-static-libs
+  - java-17-openjdk
+  - java-17-openjdk-demo
+  - java-17-openjdk-devel
+  - java-17-openjdk-headless
+  - java-17-openjdk-javadoc
+  - java-17-openjdk-javadoc-zip
+  - java-17-openjdk-jmods
+  - java-17-openjdk-src
+  - java-17-openjdk-static-libs
   - java-11-openjdk-slowdebug
   - java-11-openjdk-demo-slowdebug
   - java-11-openjdk-devel-slowdebug
@@ -39,6 +48,13 @@ data:
   - java-11-openjdk-jmods-slowdebug
   - java-11-openjdk-src-slowdebug
   - java-11-openjdk-static-libs-slowdebug
+  - java-17-openjdk-slowdebug
+  - java-17-openjdk-demo-slowdebug
+  - java-17-openjdk-devel-slowdebug
+  - java-17-openjdk-headless-slowdebug
+  - java-17-openjdk-jmods-slowdebug
+  - java-17-openjdk-src-slowdebug
+  - java-17-openjdk-static-libs-slowdebug
   - java-1.8.0-openjdk-slowdebug
   - java-1.8.0-openjdk-demo-slowdebug
   - java-1.8.0-openjdk-devel-slowdebug
@@ -56,6 +72,13 @@ data:
   - java-11-openjdk-jmods-fastdebug
   - java-11-openjdk-src-fastdebug
   - java-11-openjdk-static-libs-fastdebug
+  - java-17-openjdk-fastdebug
+  - java-17-openjdk-demo-fastdebug
+  - java-17-openjdk-devel-fastdebug
+  - java-17-openjdk-headless-fastdebug
+  - java-17-openjdk-jmods-fastdebug
+  - java-17-openjdk-src-fastdebug
+  - java-17-openjdk-static-libs-fastdebug
   # RHEL has its own portable/single build setup which uses a branch (openjdk-portable-rhel-8) rather than a separate package
   - java-1.8.0-openjdk-portable
   - java-11-openjdk-portable


### PR DESCRIPTION
The OpenJDK team only plan to support java-21-openjdk in the next release.