### PR TITLE
Add anaconda-webui package into RHEL

### DIFF
--- a/configs/sst_installer-anaconda-c9s.yaml
+++ b/configs/sst_installer-anaconda-c9s.yaml
@@ -2,12 +2,11 @@ document: feedback-pipeline-workload
 version: 1
 data:
   name: Anaconda
-  description: Graphical system installer
+  description: Graphical system installer for c9s
   maintainer: sst_installer
   labels:
-    - eln
+    - c9s
 
   packages:
     - anaconda
-    - anaconda-webui
     - anaconda-install-img-deps


### PR DESCRIPTION
This change is related to our priority to support Web UI of the Anaconda project in RHEL-10.

https://issues.redhat.com/browse/FRONTDOOR-48