### PR TITLE
Drop cyrus-sasl-ntlm from ELN

### DIFF
--- a/configs/sst_security_crypto-authentication-c9s.yaml
+++ b/configs/sst_security_crypto-authentication-c9s.yaml
@@ -11,9 +11,10 @@ data:
   - cyrus-sasl-gs2
   - cyrus-sasl-gssapi
   - cyrus-sasl-ldap
+  - cyrus-sasl-ntlm
   - cyrus-sasl-plain
   - cyrus-sasl-scram
   - cyrus-sasl-sql
 
   labels:
-  - eln
+  - c9s


### PR DESCRIPTION
The NTLM plugin has been disabled in rawhide in preparation for it being removed upstream in a future version:

https://github.com/cyrusimap/cyrus-sasl/issues/708
https://src.fedoraproject.org/rpms/cyrus-sasl/c/8a986014fe89ef82e851d5744662e201f515e146

/cc @rcritten