### PR TITLE
Remove GNOME Tweaks from RHEL 10

### DIFF
--- a/configs/sst_desktop-gnome-desktop-eln.yaml
+++ b/configs/sst_desktop-gnome-desktop-eln.yaml
@@ -28,7 +28,6 @@ data:
   - gnome-shell-extension-screenshot-window-sizer
   - gnome-shell-extension-windowsNavigator
   - gnome-shell-extension-workspace-indicator
-  - gnome-tweaks
   - gnome-browser-connector
   - libgweather
   - libproxy

--- a/configs/sst_desktop-unwanted-eln.yaml
+++ b/configs/sst_desktop-unwanted-eln.yaml
@@ -95,7 +95,9 @@ data:
   # Replaced by tecla
   - libgnomekbd
   - libxklavier
-  
+  # Mostly obsoleted
+  - gnome-tweaks
+
   unwanted_source_packages:
   # The only supported way in RHEL to render HTML content is Firefox
   - webkitgtk


### PR DESCRIPTION
It's mostly obsoleted, many things moved into GNOME Control Center, but there are still things that need investigations:
 * Minimize/maximize buttons
 * Focus on hover
 * Startup apps and how to integrate them into the current GNOME and RHEL 10 (not necessarily RHEL 10.0). For more information please see [0] (internal to Red Hat).

[0] - https://issues.redhat.com/browse/DESKTOP-743