### PR TITLE
Drop GNOME backgrounds from RHEL 10

### DIFF
--- a/configs/sst_desktop-gnome-desktop-eln.yaml
+++ b/configs/sst_desktop-gnome-desktop-eln.yaml
@@ -13,8 +13,6 @@ data:
   - glib2-devel
   - glib2-static
   - glib2-tests
-  - gnome-backgrounds
-  - gnome-backgrounds-extras
   - gnome-control-center
   - gnome-devel-docs
   - gnome-extensions-app


### PR DESCRIPTION
As agreed on the meeting with Workstation Product Manager and several UX designers we're removing GNOME backgrounds from RHEL 10 and we will be shipping a RHEL exclusive content instead. We were shipping them in earlier releases of RHEL, but the packages were not preinstalled by default.