### PR TITLE
add Secure Execution data to s390utils

### DIFF
--- a/configs/sst_arch_hw.yaml
+++ b/configs/sst_arch_hw.yaml
@@ -29,6 +29,7 @@ data:
   - pigz
   - ethtool
   - s390utils
+  - s390utils-se-data
 
   arch_packages:
     ppc64le:


### PR DESCRIPTION
The new s390utils-se-data subpackage contains noarch data for Secure Execution on the s390x platform.

Related: https://issues.redhat.com/browse/RHEL-10567