### PR TITLE
Add cockpit-ha-cluster to HA workload

### DIFF
--- a/configs/sst_high_availability-userspace.yaml
+++ b/configs/sst_high_availability-userspace.yaml
@@ -237,6 +237,14 @@ data:
         - x86_64
         - ppc64le
         - s390x
+    - rpm_name: cockpit-ha-cluster
+      dependencies:
+        - cockpit-bridge
+        # pcs (placeholder)
+      limit_arches:
+        - x86_64
+        - ppc64le
+        - s390x
   - srpm_name: python-gflags
     build_dependencies:
     - python3-devel


### PR DESCRIPTION
This is a new subpackage built from pcs srpm that will enable high-availability cluster management from Cockpit in RHEL 10, see: https://issues.redhat.com/browse/RHEL-23048.