### PR TITLE
eln: Replace pulseaudio package with pipewire-pulse

### DIFF
--- a/configs/sst_gpu-audio-playback-c9s.yaml
+++ b/configs/sst_gpu-audio-playback-c9s.yaml
@@ -12,5 +12,4 @@ data:
     - pavucontrol
 
   labels:
-    - eln
     - c9s

--- a/configs/sst_gpu-audio-playback-eln.yaml
+++ b/configs/sst_gpu-audio-playback-eln.yaml
@@ -1,0 +1,15 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Audio playback
+  description: Libraries and daemons for audio playback
+  maintainer: sst_gpu
+
+  packages:
+    - pipewire-pulseaudio
+    - libcanberra
+    - openal-soft
+    - pavucontrol
+
+  labels:
+    - eln


### PR DESCRIPTION
Pipewire has an equivalent implementation of PulseAudio's APIs, provided by `pipewire-pulse`. With Pipewire 1.0 being released and included, we feel confident that Pipewire now works well enough to remove the PulseAudio daemon itself.

In the very worst case, we can still add it back if needed.