### PR TITLE
Split idm-web-extensions to remove mod_auth_mellon

### DIFF
--- a/configs/ssg_idm-web-extensions-c9s.yaml
+++ b/configs/ssg_idm-web-extensions-c9s.yaml
@@ -7,6 +7,7 @@ data:
 
   packages:
   - mod_auth_gssapi
+  - mod_auth_mellon
   - mod_auth_openidc
   - mod_authnz_pam
   - mod_intercept_form_submit
@@ -14,4 +15,4 @@ data:
   - keycloak-httpd-client-install
 
   labels:
-  - eln
+  - c9s


### PR DESCRIPTION
mod_auth_mellon is deprecated and to be removed.  It should remain in c9s so splitting the file into one for eln and one for c9s.  The eln one has mod_auth_mellon removed.