### PR TITLE
[sst_kernel_rts] Remove eln from labels in sysfsutils

### DIFF
--- a/configs/sst_kernel_rts-sysfsutils.yaml
+++ b/configs/sst_kernel_rts-sysfsutils.yaml
@@ -8,5 +8,4 @@ data:
   - glibc
   - libsysfs 
   labels:
-  - eln
   - c9s


### PR DESCRIPTION
Removing eln from the labels, but leaving cs9. Sysfsutils is being removed from RHEL10.
