### PR TITLE
eln: Remove openal-soft from audio workload

### DIFF
--- a/configs/sst_gpu-audio-playback-eln.yaml
+++ b/configs/sst_gpu-audio-playback-eln.yaml
@@ -8,7 +8,6 @@ data:
   packages:
     - pipewire-pulseaudio
     - libcanberra
-    - openal-soft
     - pavucontrol
 
   labels:


### PR DESCRIPTION
It seems it was added as a dependency of SDL_sound and Qt5, so we should be good to remove this. If need be, we can always put it back.

Fixes: https://github.com/minimization/content-resolver-input/issues/861