### PR TITLE
Only add cockpit-ha-cluster to c10s

### DIFF
--- a/configs/sst_high_availability-userspace-c9s.yaml
+++ b/configs/sst_high_availability-userspace-c9s.yaml
@@ -237,14 +237,6 @@ data:
         - x86_64
         - ppc64le
         - s390x
-    - rpm_name: cockpit-ha-cluster
-      dependencies:
-        - cockpit-bridge
-        # pcs (placeholder)
-      limit_arches:
-        - x86_64
-        - ppc64le
-        - s390x
   - srpm_name: python-gflags
     build_dependencies:
     - python3-devel
@@ -375,5 +367,4 @@ data:
     - spausedd
 
   labels:
-  - eln
-  - c10s
+  - c9s


### PR DESCRIPTION
In #1070, I added cockpit-ha-cluster to the HA workload. However, the intention is only to ship it in c10s, not in c9s.

Can you please check that I did this right? I cannot find any documentation on how to add a package only to an upcoming release. I just based this on previous PRs and mailing list discussions.