### PR TITLE
Remove `gpm` and its subpackages from ELN

### DIFF
--- a/configs/sst_cs_system_management-sys-management-c9s.yaml
+++ b/configs/sst_cs_system_management-sys-management-c9s.yaml
@@ -6,12 +6,123 @@ data:
   maintainer: sst_cs_system_management
 
   packages:
-  - modulemd-tools
+  - babl-devel
+  - babl-devel-docs
+  - basesystem
+  - bc
+  - dcraw
+  - diffstat
+  - diffutils
+  - dos2unix
+  - eigen3-devel
+  - freeipmi
+  - freeipmi-devel
+  - gpm
+  - gpm-devel
+  - gpm-libs
+  - ipmitool
+  - iprutils
+  - jasper-devel
+  - libgphoto2-devel
+  - librabbitmq
+  - librabbitmq-devel
+  - libsmi
+  - libsmi-devel
+  - libsndfile
+  - libsndfile-devel
+  - libva
+  - libva-devel
+  - mksh
+  - netpbm-devel
+  - netpbm-doc
+  - netpbm-progs
+  - opencryptoki
+  - opencryptoki-devel
+  - opencryptoki-icsftok
+  - opencryptoki-libs
+  - opencryptoki-swtok
+  - OpenIPMI
+  - OpenIPMI-devel
+  - openwsman-server
+  - passwd
+  - patch
+  - patchutils
+  - python3-volume_key
+  - rootfiles
+  - sblim-cmpi-base
+  - sblim-gather
+  - sblim-gather-provider
+  - sblim-indication_helper
+  - sblim-sfcb
+  - sblim-sfcc-devel
+  - sblim-wbemcli
+  - symlinks
+  - tesseract
+  - tesseract-devel
+  - tesseract-langpack-eng
+  - tesseract-tessdata-doc
+  - tmpwatch
+  - tracer
+  - usermode
   - usermode-gtk
+  - uuid
+  - uuid-devel
+  - volume_key
+  - volume_key-devel
+  - volume_key-libs
+  - which
+  - wsmancli
+  - Xaw3d
+  - Xaw3d-devel
+  - mpfr
+  - mpfr-devel
+  - openexr
+  - openexr-devel
+  - openexr-libs
+  - imath
+  - imath-devel
+  - python3-imath
+  - watchdog
+  - modulemd-tools
 
   arch_packages:
+    #setserial not supported on s390x
+    aarch64:
+    - setserial
+    i686:
+    - setserial
+    x86_64:
+    - setserial
     ppc64le:
+    - setserial
     - opal-firmware
+    - opal-prd
+    - opal-utils
+    - powerpc-utils
+    - powerpc-utils-core
+    - ppc64-diag
+    - ppc64-diag-rtas
+    - libvpd
+    - libvpd-devel
+    - lsvpd
+    - libservicelog
+    - libservicelog-devel
+    - librtas
+    - librtas-devel
+    - servicelog
+    s390x:
+    - opencryptoki-ccatok
+    - opencryptoki-ep11tok
+    - opencryptoki-icatok
+
+  package_placeholders:
+    rhel-system-roles-sap:
+      srpm: rhel-system-roles-sap
+      description: system roles for SAP
+      requires: []
+      limit_arches:
+        - x86_64
+        - ppc64le
 
   labels:
   - c9s

--- a/configs/sst_cs_system_management-sys-management.yaml
+++ b/configs/sst_cs_system_management-sys-management.yaml
@@ -123,4 +123,3 @@ data:
 
   labels:
   - eln
-  - c9s

--- a/configs/sst_cs_system_management-sys-management.yaml
+++ b/configs/sst_cs_system_management-sys-management.yaml
@@ -17,9 +17,6 @@ data:
   - eigen3-devel
   - freeipmi
   - freeipmi-devel
-  - gpm
-  - gpm-devel
-  - gpm-libs
   - ipmitool
   - iprutils
   - jasper-devel

--- a/configs/sst_cs_system_management-unwanted-eln.yaml
+++ b/configs/sst_cs_system_management-unwanted-eln.yaml
@@ -22,6 +22,9 @@ data:
   - tog-pegasus-test
   - cdparanoia-static
   - dirsplit
+  - gpm
+  - gpm-devel
+  - gpm-libs
   - gpm-static
   - lensfun-tools
   - python3-lensfun


### PR DESCRIPTION
gpm provides support for using mouse on Linux text console, which is IMO a rarely used functionality and not worth maintaining.

Also split cs_system_management ELN and C9S workloads. sst_cs_system_management-sys-management.yaml had both `c9s` and `eln` labels and sst_cs_system_management-sys-management-c9s.yaml contained only the packages that are only in C9S. Make the workloads independent by copying everything from sst_cs_system_management-sys-management.yaml to sst_cs_system_management-sys-management-c9s.yaml and removing the `c9s` tag from the former. Since C9S has already branched from ELN and is independent, having separate workloads will be easier to manage than sharing the common content.