### PR TITLE
Infra Services c10s workload updates:

### DIFF
--- a/configs/sst_cs_infra_services-mta-c10s.yaml
+++ b/configs/sst_cs_infra_services-mta-c10s.yaml
@@ -14,10 +14,7 @@ data:
   - postfix-perl-scripts
   - postfix-pgsql
   - postfix-sqlite
-  - sendmail
-  - sendmail-cf
-  - sendmail-doc
-  - sendmail-milter
 
   labels:
-  - c9s
+  - eln
+  - c10s

--- a/configs/sst_cs_infra_services-spam-filtering.yaml
+++ b/configs/sst_cs_infra_services-spam-filtering.yaml
@@ -9,5 +9,4 @@ data:
   - spamassassin
 
   labels:
-  - eln
   - c9s

--- a/configs/sst_cs_infra_services-unwanted-c10s.yaml
+++ b/configs/sst_cs_infra_services-unwanted-c10s.yaml
@@ -12,6 +12,20 @@ data:
   - gutenprint-libs-ui
   # xsane
   - xsane
+  # sendmail
+  - sendmail
+  - sendmail-cf
+  - sendmail-doc
+  - sendmail-milter
+  # spamassassin
+  - spamassassin
+  # libotr
+  - libotr
+  - libotr-devel
+  # mod_security
+  - mod_security
+  - mod_security-mlogc
+  - mod_security_crs
 
   labels:
   - eln

--- a/configs/sst_cs_infra_services-varnish.yaml
+++ b/configs/sst_cs_infra_services-varnish.yaml
@@ -13,3 +13,4 @@ data:
 
   labels:
   - c9s
+  - eln


### PR DESCRIPTION
- restore varnish
- drop spamassassin, sendmail
- explicitly mark unwanted removed packages