### PR TITLE
Drop sendmail-milter-devel from ELN

### DIFF
--- a/configs/sst_cs_infra_services-development-packages-c9s.yaml
+++ b/configs/sst_cs_infra_services-development-packages-c9s.yaml
@@ -43,6 +43,8 @@ data:
   # qpdf
   - qpdf
   - qpdf-devel
+  # sendmail
+  - sendmail-milter-devel
   # tcl
   - tcl-devel
   # tk
@@ -65,5 +67,4 @@ data:
     - libi2c-devel
 
   labels:
-  - eln
-  - c10s
+  - c9s

--- a/configs/sst_cs_infra_services-unwanted-c10s.yaml
+++ b/configs/sst_cs_infra_services-unwanted-c10s.yaml
@@ -17,6 +17,7 @@ data:
   - sendmail-cf
   - sendmail-doc
   - sendmail-milter
+  - sendmail-milter-devel
   # spamassassin
   - spamassassin
   # libotr


### PR DESCRIPTION
This is a follow-up to #1085 which dropped the rest of sendmail.

/cc @notroj 