### PR TITLE
ELN: curl-minimal has been dropped

### DIFF
--- a/configs/sst_cs_plumbers-base-minimal-c9s.yaml
+++ b/configs/sst_cs_plumbers-base-minimal-c9s.yaml
@@ -7,8 +7,8 @@ data:
 
   packages:
   - coreutils-single
-  - curl
+  - curl-minimal
   - libcurl-minimal
 
   labels:
-  - eln
+  - c9s


### PR DESCRIPTION
curl and curl-minimal had converged feature-wise, so the latter was removed.  curl with libcurl-minimal is the suggested replacement.

https://bugzilla.redhat.com/show_bug.cgi?id=2262096 
https://src.fedoraproject.org/rpms/curl/c/8cec2e9cc7c18e48039a2d9dd780b0528afed8cd?branch=rawhide

/cc @jamacku @lzaoral 