### PR TITLE
Add intel-lpmd package

### DIFF
--- a/configs/sst_desktop_platform_technologies-intel-lpmd.yaml
+++ b/configs/sst_desktop_platform_technologies-intel-lpmd.yaml
@@ -1,0 +1,16 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: intel-lpmd
+  description: Intel Low Power Mode Daemon
+  maintainer: sst_desktop_platform_technologies
+
+  packages: []
+
+  labels:
+  - eln
+  - c9s
+
+  arch_packages:
+   x86_64:
+   - intel-lpmd


### PR DESCRIPTION
Add intel-lpmd package to enable Low Power Mode on Intel Meteor Lake platforms.
See https://issues.redhat.com/browse/RHEL-20167.