### PR TITLE
Alsa updates

### DIFF
--- a/configs/sst_arch_hw.yaml
+++ b/configs/sst_arch_hw.yaml
@@ -23,6 +23,7 @@ data:
   - alsa-plugins-usbstream
   - alsa-plugins-vdownmix
   - alsa-tools-firmware
+  - alsa-ucm
   - alsa-utils
   - speexdsp
   - hwloc
@@ -78,6 +79,5 @@ data:
       - glibc
 
   labels:
-  - eln
   - c9s
 

--- a/configs/sst_arch_hw_eln.yaml
+++ b/configs/sst_arch_hw_eln.yaml
@@ -1,0 +1,83 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: arch hw packages
+  description: Packages for hardware enablement
+  maintainer: sst_arch_hw
+
+  packages:
+  - mdadm
+  - nvme-cli
+  - acpica-tools
+  - bluez
+  - alsa-firmware
+  - alsa-sof-firmware
+  - alsa-lib
+  - alsa-plugins-arcamav
+  - alsa-plugins-maemo
+  - alsa-plugins-oss
+  - alsa-plugins-pulseaudio
+  - alsa-plugins-samplerate
+  - alsa-plugins-speex
+  - alsa-plugins-upmix
+  - alsa-plugins-usbstream
+  - alsa-plugins-vdownmix
+  - alsa-tools-firmware
+  - alsa-ucm
+  - alsa-ucm-utils
+  - alsa-utils
+  - speexdsp
+  - hwloc
+  - pigz
+  - ethtool
+  - s390utils
+  - s390utils-se-data
+
+  arch_packages:
+    ppc64le:
+    - libnxz
+    - libnxz-devel
+    - libnxz-static
+    - libocxl
+    - libocxl-devel
+    s390x:
+    - qclib
+    - qclib-devel
+    - qclib-static
+    - libica
+    - libica-devel
+    - libzdnn
+    - libzdnn-devel
+    - libzdnn-static
+    - libzfcphbaapi
+    - libzfcphbaapi-devel
+    - libzfcphbaapi-docs
+    - libzpc
+    - libzpc-devel
+    - openssl-ibmca
+    - s390utils-base
+    - s390utils-chreipl-fcp-mpath
+    - s390utils-cmsfs-fuse
+    - s390utils-core
+    - s390utils-cpacfstatsd
+    - s390utils-cpuplugd
+    - s390utils-devel
+    - s390utils-hmcdrvfs
+    - s390utils-iucvterm
+    - s390utils-mon_statd
+    - s390utils-osasnmpd
+    - s390utils-zdsfs
+    - s390utils-ziomon
+    x86_64:
+    - mcelog
+    - tboot
+
+  package_placeholders:
+    dptfxtract:
+      srpm: dptfxtract
+      description: dptfxtract utility
+      requires:
+      - glibc
+
+  labels:
+  - eln


### PR DESCRIPTION
Add the proper alsa file for rhel10 to the eln file.  Limit the addition of ucm files to c9s because we don't have alsa-ucm-utils there.  Supersedes pull request #1072 