### PR TITLE
support-tools-container is not an RPM

### DIFF
--- a/configs/cee-support-workload.yaml
+++ b/configs/cee-support-workload.yaml
@@ -14,7 +14,3 @@ data:
   labels:
   - eln
   - c9s
-
-  package_placeholders:
-    support-tools-container:
-      description: This package ships in RHEL as a support tool, but does not ship in Fedora. 


### PR DESCRIPTION
Content Resolver is designed to track RPMs, not containers.