### PR TITLE
Drop NetworkManager-team subpackage in ELN and c10s

### DIFF
--- a/configs/sst_network_management-unwanted-c10s.yaml
+++ b/configs/sst_network_management-unwanted-c10s.yaml
@@ -1,0 +1,13 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Network Management unwanted
+  description: >
+    Unwanted packages from Network Management
+
+  maintainer: sst_network_management
+  unwanted_packages:
+    - NetworkManager-team
+  labels:
+    - eln
+    - c10s

--- a/configs/sst_network_management-unwanted-c10s.yaml
+++ b/configs/sst_network_management-unwanted-c10s.yaml
@@ -8,6 +8,9 @@ data:
   maintainer: sst_network_management
   unwanted_packages:
     - NetworkManager-team
+    - libteam
+    - teamd
+    - teamd-devel
   labels:
     - eln
     - c10s


### PR DESCRIPTION
Drop NetworkManager-team subpackage in ELN and c10s. 