### PR TITLE
Don't ship anaconda-webui in RHEL-10

### DIFF
--- a/configs/sst_installer-anaconda.yaml
+++ b/configs/sst_installer-anaconda.yaml
@@ -9,5 +9,4 @@ data:
     - c10s
   packages:
     - anaconda
-    - anaconda-webui
     - anaconda-install-img-deps


### PR DESCRIPTION
There were change of plans for RHEL-10 so we decided to remove this package c10s for now.

[FRONTDOOR-48 comment](https://issues.redhat.com/browse/FRONTDOOR-48?focusedId=24265211&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24265211)