### PR TITLE
LLVM 18 updates

### DIFF
--- a/configs/sst_pt_llvm_rust_go-llvm-toolset-exclusion.yaml
+++ b/configs/sst_pt_llvm_rust_go-llvm-toolset-exclusion.yaml
@@ -55,6 +55,14 @@ data:
     - llvm15-devel
     - llvm15-libs
     - llvm15-static
+    - llvm16
+    - llvm16-devel
+    - llvm16-libs
+    - llvm16-static
+    - llvm17
+    - llvm17-devel
+    - llvm17-libs
+    - llvm17-static
   labels:
     - eln
     - c9s

--- a/configs/sst_pt_llvm_rust_go-llvm-toolset.yaml
+++ b/configs/sst_pt_llvm_rust_go-llvm-toolset.yaml
@@ -19,32 +19,15 @@ data:
     - git-clang-format
     - python3-clang
     - compiler-rt
+    - libomp
+    - libomp-devel
+    - lld
+    - lld-devel
+    - lld-libs
     - lldb
     - lldb-devel
     - python3-lldb
     - python3-lit
-  arch_packages:
-    aarch64:
-      - libomp
-      - libomp-devel
-      - lld
-      - lld-devel
-      - lld-libs
-    ppc64le:
-      - libomp
-      - libomp-devel
-      - lld
-      - lld-devel
-      - lld-libs
-    x86_64:
-      - libomp
-      - libomp-devel
-      - lld
-      - lld-devel
-      - lld-libs
-    armv7hl:
-      - libomp
-      - libomp-devel
   labels:
     - eln
     - c10s


### PR DESCRIPTION
libomp and lld are now enabled in 18, which is now in ELN, and expected in RHEL 10 in due course.  Also, mark 16 and 17 as unwanted.

/cc @tstellar 