### PR TITLE
Fixup the Python devel (CRB) workload for c10s

### DIFF
--- a/configs/sst_cs_apps-python-crb-c10s.yaml
+++ b/configs/sst_cs_apps-python-crb-c10s.yaml
@@ -18,8 +18,8 @@ data:
     - python3-cython
     - python3-sphinx
     - python3-wheel
-    # note: the following package is called python3-wheel-wheel in RHEL proper:
-    - python-wheel-wheel
+    # note: the following package is called python-wheel-wheel in ELN:
+    - python3-wheel-wheel
     - python3-pytest
     - python3-psutil-tests
     - py3c-devel
@@ -31,4 +31,4 @@ data:
     - python3-installer
     - python3-pyproject-hooks
   labels:
-    - eln
+    - c10s


### PR DESCRIPTION
sst_cs_apps-python-crb-c10s.yaml is a copy of sst_cs_apps-python-crb-eln.yaml.

 - labels were adjusted (split)
 - python-wheel-wheel is called python3-wheel-wheel in c10s