### PR TITLE
Make prefixdevname a real package

### DIFF
--- a/configs/sst_cs_plumbers-hw-tools.yaml
+++ b/configs/sst_cs_plumbers-hw-tools.yaml
@@ -11,19 +11,12 @@ data:
     - numad
     - sgpio
     - libatasmart
+    - prefixdevname
   arch_packages:
     x86_64:
       - biosdevname
     i686:
       - biosdevname
-  package_placeholders:
-    prefixdevname:
-      srpm: prefixdevname
-      description: This package is rhel-only NIC naming tool
-      buildrequires:
-        - rust-toolset
-        - git
-        - systemd-devel
   labels:
     - eln
     - c10s

--- a/configs/sst_program-lorax-template-eln.yaml
+++ b/configs/sst_program-lorax-template-eln.yaml
@@ -61,8 +61,7 @@ data:
     - tigervnc-server-minimal
     - net-tools
     - nmap-ncat
-    # asamalik: this package is not in Fedora
-    # - prefixdevname
+    - prefixdevname
     - pciutils
     - usbutils
     - ipmitool


### PR DESCRIPTION
rust-prefixdevname (RPM: prefixdevname, previously RHEL-specific) is now in Fedora, and lorax now expects it to be available:

https://github.com/weldr/lorax/commit/ffba3078beab843c5d663f6443dca28d8e820948
