### PR TITLE
Drop shim-ia32 and grub2-efi-ia32-cdboot from ELN

### DIFF
--- a/configs/sst_program-lorax-template-eln.yaml
+++ b/configs/sst_program-lorax-template-eln.yaml
@@ -96,8 +96,6 @@ data:
       - efibootmgr
       - shim-x64
       - grub2-efi-x64-cdboot
-      - shim-ia32
-      - grub2-efi-ia32-cdboot
       - biosdevname
       - memtest86+
       - syslinux


### PR DESCRIPTION
https://src.fedoraproject.org/rpms/lorax-templates-rhel/pull-request/9
https://gitlab.com/redhat/centos-stream/rpms/lorax-templates-rhel/-/commit/2a5ee65a6dbd2c3f868c93ee800d12c657b98ef1

/cc @sgallagher @bstinsonmhk
