### PR TITLE
eln-extras: drop bitstower-markets

### DIFF
--- a/configs/eln_extras_yselkowitz.yaml
+++ b/configs/eln_extras_yselkowitz.yaml
@@ -5,7 +5,6 @@ data:
   description: Yaakov Selkowitzs ELN Extras packages
   maintainer: yselkowitz
   packages:
-    - bitstower-markets
     - flatseal
     - latex2rtf
     - robodoc


### PR DESCRIPTION
This package was abandoned upstream and retired downstream.
