### PR TITLE
Drop awscli from ELN Extras for Meta

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -6,7 +6,6 @@ data:
   maintainer: meta-sig
   packages:
     - atop
-    - awscli
     - azure-cli
     - b4
     - below


### PR DESCRIPTION
The awscli2 package has replaced and provides awscli, and is in ELN. Furthermore, while noarch, it cannot be installed on s390x due to arch limiations in python-awscrt (rhbz#2180988).  Therefore, if relisted in the future, it must be limited to installable architectures in the workload.

/cc @davide125 