### PR TITLE
eln_extras_meta: add libxcrypt-compat

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -45,6 +45,7 @@ data:
     - libkdumpfile-devel
     - libidn
     - libidn-devel
+    - libxcrypt-compat
     - linux-sysinfo-snapshot
     - mlnx-tools
     - mkosi


### PR DESCRIPTION
This is no longer built as part of libxcrypt in RHEL >= 10 but is still needed by Chef, so it is now built from a separate libxcrypt-epel package:

https://koji.fedoraproject.org/koji/packageinfo?packageID=39931