### PR TITLE
Mark libxcrypt-compat as unwanted in ELN

### DIFF
--- a/configs/sst_pt_libraries-unwanted-eln.yaml
+++ b/configs/sst_pt_libraries-unwanted-eln.yaml
@@ -10,3 +10,5 @@ data:
   unwanted_packages:
     # Remove nscd in favour of sssd.
     - nscd
+    # Removed from libxcrypt
+    - libxcrypt-compat


### PR DESCRIPTION
libxcrypt-compat (libcrypt.so.1) was dropped from c10s and ELN libxcrypt, but is still used for binary compatibility with third-party solutions.  Therefore, it is eligible for EPEL 10 and ELN Extras, but is unwanted in ELN itself.

https://src.fedoraproject.org/rpms/libxcrypt/pull-request/16
https://src.fedoraproject.org/rpms/nbdkit/pull-request/5
https://github.com/minimization/content-resolver-input/pull/1124
