### PR TITLE
Adding openscap-report to RHEL9

### DIFF
--- a/configs/sst_security_compliance-reporting.yaml
+++ b/configs/sst_security_compliance-reporting.yaml
@@ -8,4 +8,5 @@ data:
     - openscap-report
   labels:
     - eln
+    - c9s
     - c10s


### PR DESCRIPTION
Having `openscap-report` in RHEL9 will help us consolidate experience across supported version.

Related: RHEL-31755