### PR TITLE
Adding openscap-report to RHEL8

### DIFF
--- a/configs/sst_security_compliance-reporting.yaml
+++ b/configs/sst_security_compliance-reporting.yaml
@@ -8,5 +8,6 @@ data:
     - openscap-report
   labels:
     - eln
+    - c8s
     - c9s
     - c10s


### PR DESCRIPTION
Having `openscap-report` in RHEL8 will help us consolidate experience across supported version.

Related: RHEL-32208