### PR TITLE
Add zenity to CR

### DIFF
--- a/configs/sst_desktop-gnome-desktop-eln.yaml
+++ b/configs/sst_desktop-gnome-desktop-eln.yaml
@@ -33,6 +33,7 @@ data:
     - tracker
     - tracker-miners
     - xdg-user-dirs-gtk
+    - zenity
   labels:
     - eln
     - c10s

--- a/configs/sst_desktop-gnome-desktop.yaml
+++ b/configs/sst_desktop-gnome-desktop.yaml
@@ -37,6 +37,7 @@ data:
     - tracker
     - tracker-miners
     - xdg-user-dirs-gtk
+    - zenity
   labels:
     - c9s
   package_placeholders:


### PR DESCRIPTION
Previously it was pulled by Gedit and Mutter, but we replaced Gedit with GNOME Text Editor and the dependency was dropped from Mutter, so fix this for ELN/RHEL 11 and slowly start the PRP process for RHEL 10..