### PR TITLE
ELN: add wireguard-tools

### DIFF
--- a/configs/sst_networking_core-wireguard-tools.yaml
+++ b/configs/sst_networking_core-wireguard-tools.yaml
@@ -1,0 +1,12 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: wireguard-tools
+  description: Fast, modern, secure VPN tunnel
+  maintainer: sst_networking_core
+  packages:
+    - wireguard-tools
+  labels:
+    - eln
+    - c9s
+    - c10s


### PR DESCRIPTION
Somehow we forgot to add wireguard-tools to ELN. It is present on RHEL9, and we also plan to have it on RHEL10.