### PR TITLE
network/lldp: add devel packages

### DIFF
--- a/configs/sst_network_fastdatapath-tools-lldp.yaml
+++ b/configs/sst_network_fastdatapath-tools-lldp.yaml
@@ -9,7 +9,9 @@ data:
   packages:
     # LLDP support
     - lldpad
+    - lldpad-devel
     - lldpd
+    - lldpd-devel
   labels:
     - eln
     - c9s


### PR DESCRIPTION
Customers unable to compile internal software using functions defined in `/usr/include/lldpctl.h`. 
See Jira issue [RHEL-22127](https://issues.redhat.com/browse/RHEL-22127).