### PR TITLE
Add makedumpfile subpackage to ELN and c10s.

### DIFF
--- a/configs/sst_kernel_debug-kdump-c9s.yaml
+++ b/configs/sst_kernel_debug-kdump-c9s.yaml
@@ -14,7 +14,6 @@ data:
     - crash-trace-command
     - libkdumpfile
     - drgn
-    - makedumpfile
     # Read ftrace data from a core dump file.
   arch_packages:
     aarch64:
@@ -25,5 +24,4 @@ data:
     x86_64:
       - crash-gcore-command
   labels:
-    - eln
-    - c10s
+    - c9s


### PR DESCRIPTION
We added a new subpackage makedumpfile in Fedora and RHEL-10.