### PR TITLE
Update config-check action to checkout@v4

### DIFF
--- a/.github/workflows/config-check.yml
+++ b/.github/workflows/config-check.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
 
     - name: Checkout code repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: minimization/content-resolver
         path: code
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: code/input
 


### PR DESCRIPTION
This should fix the "Node.js 16 actions are deprecated" warning in our CI jobs.  The only differences between checkout@v3 and v4 is the switch to nodejs-20 and the addition of a showProgress option.