### PR TITLE
Add kdump-utils subpackage to ELN and c10s.

### DIFF
--- a/configs/sst_kernel_debug-kdump.yaml
+++ b/configs/sst_kernel_debug-kdump.yaml
@@ -15,6 +15,7 @@ data:
     - libkdumpfile
     - drgn
     - makedumpfile
+    - kdump-utils
     # Read ftrace data from a core dump file.
   arch_packages:
     aarch64:


### PR DESCRIPTION
We added a new subpackage kdump-utils in Fedora and RHEL-10.