### PR TITLE
Update ruby workload to include rubygem-racc on C10S + ELN

### DIFF
--- a/configs/sst_cs_apps-ruby-c9s.yaml
+++ b/configs/sst_cs_apps-ruby-c9s.yaml
@@ -1,0 +1,30 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Ruby runtime
+  description: Ruby interpretter and the most basic libraries
+  maintainer: sst_cs_apps
+  packages:
+    - ruby
+    - ruby-default-gems
+    - ruby-devel
+    - ruby-libs
+    - rubygem-bigdecimal
+    - rubygem-bundler
+    - rubygem-io-console
+    - rubygem-irb
+    - rubygem-json
+    - rubygem-minitest
+    - rubygem-power_assert
+    - rubygem-psych
+    - rubygem-rake
+    - rubygem-rbs
+    - rubygem-rdoc
+    - rubygem-rexml
+    - rubygem-rss
+    - rubygem-test-unit
+    - rubygem-typeprof
+    - rubygems
+    - rubygems-devel
+  labels:
+    - c9s

--- a/configs/sst_cs_apps-ruby-eln.yaml
+++ b/configs/sst_cs_apps-ruby-eln.yaml
@@ -17,6 +17,7 @@ data:
     - rubygem-minitest
     - rubygem-power_assert
     - rubygem-psych
+    - rubygem-racc
     - rubygem-rake
     - rubygem-rbs
     - rubygem-rdoc

--- a/configs/sst_cs_apps-ruby-eln.yaml
+++ b/configs/sst_cs_apps-ruby-eln.yaml
@@ -28,5 +28,4 @@ data:
     - rubygems-devel
   labels:
     - eln
-    - c9s
     - c10s


### PR DESCRIPTION
rubygem-racc is in buildroot 1 currently, however since it should be provided by the Ruby SRPM from c10s onward. Therefore, it should be part of the Ruby workload to be in the correct class of packages.

@voxik FYI