### PR TITLE
add cs10 tag for kpatch packages

### DIFF
--- a/configs/sst_kernel_security-kpatch.yaml
+++ b/configs/sst_kernel_security-kpatch.yaml
@@ -8,6 +8,7 @@ data:
   labels: # <-- Please leave
     - eln #     this unchanged.
     - c9s
+    - c10s
   package_placeholders:
     # kpatch is a RHEL-only package
     kpatch:


### PR DESCRIPTION
The kpatch packages are RHEL-specific and not supported on Fedora.  Add the cs10 tag for inclusion in RHEL-10.