### PR TITLE
Add forgotten CS system management pkgs from RHEL 9

### DIFF
--- a/configs/sst_cs_system_management-sys-management.yaml
+++ b/configs/sst_cs_system_management-sys-management.yaml
@@ -43,6 +43,7 @@ data:
     - passwd
     - patch
     - patchutils
+    - python3-pyghmi
     - python3-volume_key
     - rootfiles
     - sblim-cmpi-base
@@ -59,6 +60,7 @@ data:
     - tesseract-tessdata-doc
     - tmpwatch
     - tracer
+    - udftools
     - usermode
     - uuid
     - uuid-devel


### PR DESCRIPTION
These packages got added to RHEL 9, but never got into workloads.

Correct this for ELN and RHEL 10.

udftools: https://bugzilla.redhat.com/show_bug.cgi?id=1949905
python3-pyghmi: https://bugzilla.redhat.com/show_bug.cgi?id=2023376