### PR TITLE
sst_network_drivers: remove fabtests from Appstream

### DIFF
--- a/configs/sst_network_drivers-appstream.yaml
+++ b/configs/sst_network_drivers-appstream.yaml
@@ -6,7 +6,6 @@ data:
   maintainer: sst_network_drivers
   packages:
     - libfabric-devel
-    - fabtests
     - openmpi
     - openmpi-devel
     - openmpi-java


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHEL-12293

It pulls in python3-pytest, which we don't want to maintain.