### PR TITLE
sst_network_drivers: drop fabtests and mvapich2 from eln and c10s

### DIFF
--- a/configs/sst_network_drivers-appstream-c9s.yaml
+++ b/configs/sst_network_drivers-appstream-c9s.yaml
@@ -2,7 +2,7 @@ document: feedback-pipeline-workload
 version: 1
 data:
   name: RDMA Stack Appstream Packages
-  description: RDMA Stack - Packages should be in ELN
+  description: RDMA Stack - Packages should be in c9s
   maintainer: sst_network_drivers
   packages:
     - libfabric-devel
@@ -18,8 +18,7 @@ data:
     - mpich-doc
     - python3-mpich
   labels:
-    - eln
-    - c10s
+    - c9s
   arch_packages:
     # not armv7hl
     aarch64:

--- a/configs/sst_network_drivers-appstream.yaml
+++ b/configs/sst_network_drivers-appstream.yaml
@@ -6,7 +6,6 @@ data:
   maintainer: sst_network_drivers
   packages:
     - libfabric-devel
-    - fabtests
     - openmpi
     - openmpi-devel
     - openmpi-java

--- a/configs/sst_network_drivers-rhel-only-c9s.yaml
+++ b/configs/sst_network_drivers-rhel-only-c9s.yaml
@@ -2,7 +2,7 @@ document: feedback-pipeline-workload
 version: 1
 data:
   name: RDMA Stack RHEL Only
-  description: RDMA Stack RHEL Only - Packages should be in ELN
+  description: RDMA Stack RHEL Only - Packages should be in c9s
   maintainer: sst_network_drivers
   # this field is mandatory
   packages: []
@@ -50,5 +50,4 @@ data:
       requires:
         - openmpi
   labels:
-    - eln
-    - c10s
+    - c9s

--- a/configs/sst_network_drivers-rhel-only.yaml
+++ b/configs/sst_network_drivers-rhel-only.yaml
@@ -7,43 +7,11 @@ data:
   # this field is mandatory
   packages: []
   package_placeholders:
-    mvapich2:
-      srpm: mvapich2
-      description: This package is not in Fedora (yet), but we want to see it here.
-      requires:
-        - environment-modules
-        - hwloc-libs
-        - python3
-        - perl-interpreter
-      buildrequires:
-        - perl-Digest-MD5
-        - hwloc-devel
-        - bison
-        - flex
-        - rpm-mpi-hooks
-    mvapich2-devel:
-      srpm: mvapich2
-      description: This package is not in Fedora (yet), but we want to see it here.
-      #requires:
-      #- mvapich2  asamalik: I'm commenting mvapich2 out as it's a placeholder, and this
-      #                      field is meant to be used to pull existing packages in.
-      #                      Since mvapich2 is listed, it'll be on the list anyway,
-      #                      so this won't change anything. Just stops the workload from failing.
-    mvapich2-doc:
-      srpm: mvapich2
-      description: This package is not in Fedora (yet), but we want to see it here.
-      #requires:
-      #- mvapich2
     mpitests-mpich:
       srpm: mpitests
       description: This package is not in Fedora (yet), but we want to see it here.
       requires:
         - mpich
-    mpitests-mvapich2:
-      srpm: mpitests
-      description: This package is not in Fedora (yet), but we want to see it here.
-      #requires:
-      #- mvapich2
     mpitests-openmpi:
       srpm: mpitests
       description: This package is not in Fedora (yet), but we want to see it here.


### PR DESCRIPTION
For the fabtests removal:
JIRA: https://issues.redhat.com/browse/RHEL-12293

For removing mvapich2: In our SST meting, we agreed we can't maintain multiple MPI implementations.