### PR TITLE
updates for libmemcached/libmemcached-awesome

### DIFF
--- a/configs/sst_cs_infra_services-databases-c9s.yaml
+++ b/configs/sst_cs_infra_services-databases-c9s.yaml
@@ -5,10 +5,10 @@ data:
   description: Data storage software
   maintainer: sst_cs_infra_services
   packages:
+    - libmemcached-awesome
     - memcached
     - memcached-selinux
     - rrdtool
     - tinycdb
   labels:
-    - eln
-    - c10s
+    - c9s

--- a/configs/sst_cs_infra_services-unwanted-c10s.yaml
+++ b/configs/sst_cs_infra_services-unwanted-c10s.yaml
@@ -26,6 +26,10 @@ data:
     - mod_security
     - mod_security-mlogc
     - mod_security_crs
+    # libmemcached
+    - libmemcached-awesome
+    - libmemcached-awesome-devel
+    - libmemcached-awesome-tools
   labels:
     - eln
     - c10s


### PR DESCRIPTION
Update c9s workflows to reflect that libmemcached-awesome replaced libmemcached (from 9.0)

Update c10s+ workflows to remove libmemcached-awesome (RHEL-34695)