### PR TITLE
Unwanted: efs-utils + efs-utils-selinux

### DIFF
--- a/configs/sst_cloud_experience.yaml
+++ b/configs/sst_cloud_experience.yaml
@@ -5,8 +5,6 @@ data:
   description: Software that makes RHEL more integrated with various clouds
   maintainer: sst_cloud_experience
   packages:
-    - efs-utils
-    - efs-utils-selinux
     - python3-botocore
     - python3-prompt-toolkit
     - python3-ruamel-yaml


### PR DESCRIPTION
We cannot package efs-utils and efs-utils-selinux any longer due to upstream changes.