### PR TITLE
Remove mdadm from sst_arch_hw_eln.yaml

### DIFF
--- a/configs/sst_arch_hw.yaml
+++ b/configs/sst_arch_hw.yaml
@@ -5,7 +5,6 @@ data:
   description: Packages for hardware enablement
   maintainer: sst_arch_hw
   packages:
-    - mdadm
     - nvme-cli
     - acpica-tools
     - bluez

--- a/configs/sst_arch_hw_eln.yaml
+++ b/configs/sst_arch_hw_eln.yaml
@@ -5,7 +5,6 @@ data:
   description: Packages for hardware enablement
   maintainer: sst_arch_hw
   packages:
-    - mdadm
     - nvme-cli
     - acpica-tools
     - bluez


### PR DESCRIPTION
The mdadm package is required for the storage workload (which is where it should be).  It does not need to be required by arch_hw which no longer has any control over the md raid subsystem that mdadm is used to manage.