### PR TITLE
Update arch_hw config with two patches to remove unnecessary includes

### DIFF
--- a/configs/sst_arch_hw_eln.yaml
+++ b/configs/sst_arch_hw_eln.yaml
@@ -5,7 +5,6 @@ data:
   description: Packages for hardware enablement
   maintainer: sst_arch_hw
   packages:
-    - nvme-cli
     - acpica-tools
     - bluez
     - alsa-firmware

--- a/configs/sst_arch_hw_eln.yaml
+++ b/configs/sst_arch_hw_eln.yaml
@@ -5,7 +5,6 @@ data:
   description: Packages for hardware enablement
   maintainer: sst_arch_hw
   packages:
-    - mdadm
     - nvme-cli
     - acpica-tools
     - bluez


### PR DESCRIPTION
This includes two patches (one already covered under another pull request) to remove unneeded items from the arch_hw package definitions.  In both cases, the packages are also included via other mechanisms, so no changes to the actual RHEL10 package set will happen, this will just clean up who/why the packages are being included.