### PR TITLE
classify `Xaw3d` only as a dependency in `c10s`

### DIFF
--- a/configs/sst_cs_system_management-sys-management.yaml
+++ b/configs/sst_cs_system_management-sys-management.yaml
@@ -67,8 +67,6 @@ data:
     - volume_key-libs
     - which
     - wsmancli
-    - Xaw3d
-    - Xaw3d-devel
     - mpfr
     - mpfr-devel
     - openexr


### PR DESCRIPTION
cc: @jacekmigacz