### PR TITLE
Remove nvme-cli from sst_arch_hw_eln.yaml

### DIFF
--- a/configs/sst_arch_hw_eln.yaml
+++ b/configs/sst_arch_hw_eln.yaml
@@ -5,7 +5,6 @@ data:
   description: Packages for hardware enablement
   maintainer: sst_arch_hw
   packages:
-    - nvme-cli
     - acpica-tools
     - bluez
     - alsa-firmware


### PR DESCRIPTION
This package is not maintained by arch_hw.  It is required by anaconda-install-img-deps as shown by https://tiny.distro.builders/view-rpm--view-eln--nvme-cli.html and so will still be included in the install image.  If it is wanted post-install, then likely storage_ssg should pull it in as a requirement.