### PR TITLE
Mark openslp-server as unwanted

### DIFF
--- a/configs/sst_cs_system_management-unwanted-eln.yaml
+++ b/configs/sst_cs_system_management-unwanted-eln.yaml
@@ -65,6 +65,7 @@ data:
     - gimp-libs
     - gegl04
     - mypaint-brushes
+    - openslp-server
   labels:
     - eln
     - c10s


### PR DESCRIPTION
OpenSLP upstream is not active and the package often suffers from security issues. Some of them are even not fixable due to protocol design flaws. However, client and devel part are still needed.