### PR TITLE
mark `python3-pycurl` as unwanted in C10S and ELN

### DIFF
--- a/configs/sst_cs_plumbers-unwanted.yaml
+++ b/configs/sst_cs_plumbers-unwanted.yaml
@@ -31,6 +31,7 @@ data:
     - network-scripts
     - pinfo
     - python3-bottle
+    - python3-pycurl
     - redhat-lsb
     - redhat-lsb-core
     - redhat-lsb-cxx

--- a/configs/sst_high_availability-userspace.yaml
+++ b/configs/sst_high_availability-userspace.yaml
@@ -23,7 +23,6 @@ data:
             - gnutls-utils
             - net-snmp-utils
             - openssh-clients
-            - python3-pycurl
         - rpm_name: fence-agents-aliyun
           description: This package is only provided in RHEL
           dependencies:
@@ -53,8 +52,7 @@ data:
             - x86_64
         - rpm_name: fence-agents-common
           description: Built with bundled dependencies in RHEL
-          dependencies:
-            - python3-pycurl
+          dependencies: []
         - rpm_name: fence-agents-compute
           description: Built with bundled dependencies in RHEL
           dependencies:
@@ -180,7 +178,6 @@ data:
         - python3-dateutil
         - python3-devel
         - python3-setuptools
-        - python3-pycurl
         - python3-pip
         - python3-pyparsing
         - python3-lxml
@@ -213,7 +210,6 @@ data:
             - python3-cryptography
             - python3-dateutil
             - python3-lxml
-            - python3-pycurl
             - python3-pyparsing
             - python3-setuptools
             - redhat-logos


### PR DESCRIPTION
All users of `python3-pycurl` are already patched to remove this dependency in C10S and ELN.  See the issue below for the progress.

Related: https://issues.redhat.com/browse/RHEL-26342