### PR TITLE
eln: Mark some remaining Xorg packages as unwanted

### DIFF
--- a/configs/sst_gpu-unwanted-eln.yaml
+++ b/configs/sst_gpu-unwanted-eln.yaml
@@ -46,6 +46,8 @@ data:
     - glew
     # Xorg removal in RHEL 10
     - xorg-x11-server-common
+    - xorg-x11-server-devel
+    - xorg-x11-server-source
     - xorg-x11-server-Xorg
     - xorg-x11-server-Xnest
     - xorg-x11-server-Xdmx


### PR DESCRIPTION
Some packages that are generated from the xorg-x11-server source package have not been marked as unwanted yet, so let's do that here. The only packages that still rely on them (mostly tigervnc or some Xorg drivers) are also marked as unwanted and are slated for removal too.