### PR TITLE
eln: Mark pulseaudio daemon package as unwanted

### DIFF
--- a/configs/sst_gpu-unwanted-eln.yaml
+++ b/configs/sst_gpu-unwanted-eln.yaml
@@ -60,6 +60,9 @@ data:
     - xorg-x11-drv-modesetting
     - xorg-x11-drv-vmware
     - xorg-x11-drv-wacom
+    # Removed in favor of pipewire(-pulse). Note that the SRPM with the same
+    # name should still be built for some packages, like pulseaudio-libs
+    - pulseaudio
   labels:
     - eln
     - c10s


### PR DESCRIPTION
The daemon is removed in favor of Pipewire (which contains an implementation still of the PulseAudio API)