### PR TITLE
Revert "sst_network_drivers: remove fabtests from Appstream"

### DIFF
--- a/configs/sst_network_drivers-appstream.yaml
+++ b/configs/sst_network_drivers-appstream.yaml
@@ -6,6 +6,7 @@ data:
   maintainer: sst_network_drivers
   packages:
     - libfabric-devel
+    - fabtests
     - openmpi
     - openmpi-devel
     - openmpi-java


### PR DESCRIPTION
fabtests needs to be moved to CRB, not removed entirely.

This reverts commit e3e56f354f687e7bb52c18119b36be0bd264aa06 from #1144 .

/cc @michich 