### PR TITLE
c9s: revert rename of `emacs-nox`

### DIFF
--- a/configs/sst_cs_plumbers-editors-c9s.yaml
+++ b/configs/sst_cs_plumbers-editors-c9s.yaml
@@ -7,9 +7,8 @@ data:
   packages:
     - emacs
     - emacs-lucid
-    - emacs-nw
+    - emacs-nox
     - emacs-auctex
     - nano
   labels:
-    - eln
-    - c10s
+    - c9s


### PR DESCRIPTION
The renamed package is only present in c10s and ELN and there were no plans to to rename it also in c9s.

Fixes: 7126256bea6d2cdba01ea8640d28c8aac5756cf5 ("sst_cs_plumbers-editors: emacs-nox -> emacs-nw")

cc: @jacekmigacz