### PR TITLE
Remove usb_modeswitch from c10s & eln

### DIFF
--- a/configs/sst_network_management-main.yaml
+++ b/configs/sst_network_management-main.yaml
@@ -16,8 +16,6 @@ data:
     - NetworkManager-ppp
     - NetworkManager-wwan
     - mobile-broadband-provider-info
-    - usb_modeswitch
-    - usb_modeswitch-data
     # VPN
     - NetworkManager-libreswan
     - NetworkManager-libreswan-gnome

--- a/configs/sst_network_management-unwanted-c10s.yaml
+++ b/configs/sst_network_management-unwanted-c10s.yaml
@@ -13,6 +13,8 @@ data:
     - teamd-devel
     - nispor
     - python3-nispor
+    - usb_modeswitch
+    - usb_modeswitch-data
   labels:
     - eln
     - c10s

--- a/configs/sst_network_management-usb_modeswitch.yaml
+++ b/configs/sst_network_management-usb_modeswitch.yaml
@@ -1,0 +1,14 @@
+---
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Network Management USB Mode Switching
+  description: >
+    Support for switching mode of legacy (3G) USB modem dongles
+
+  maintainer: sst_network_management
+  packages:
+    - usb_modeswitch
+    - usb_modeswitch_data
+  labels:
+    - c9s


### PR DESCRIPTION
No reasonably modern hardware should require this.

Also, it's a fairly oddball thing -- written TCL, bundling a TCL interpreter.