### PR TITLE
replace `mlocate` with `plocate` in c10s and eln

### DIFF
--- a/configs/sst_cs_plumbers-cli-tools.yaml
+++ b/configs/sst_cs_plumbers-cli-tools.yaml
@@ -8,7 +8,7 @@ data:
     - usbutils
     - procps-ng
     - sysstat
-    - mlocate
+    - plocate
     - mtr
     - mtr-gtk
     - environment-modules


### PR DESCRIPTION
Related: https://issues.redhat.com/browse/RHEL-36785

cc: @msekletar