### PR TITLE
remove ethtool from sst_arch_hw

### DIFF
--- a/configs/sst_arch_hw.yaml
+++ b/configs/sst_arch_hw.yaml
@@ -26,7 +26,6 @@ data:
     - speexdsp
     - hwloc
     - pigz
-    - ethtool
     - s390utils
     - s390utils-se-data
   arch_packages:

--- a/configs/sst_arch_hw_eln.yaml
+++ b/configs/sst_arch_hw_eln.yaml
@@ -26,7 +26,6 @@ data:
     - speexdsp
     - hwloc
     - pigz
-    - ethtool
     - s390utils
     - s390utils-se-data
   arch_packages:


### PR DESCRIPTION
ethtool is maintained by the sst_networking_core for quite some time, so remove from sst_arch_hw.

CC: @dledford 