### PR TITLE
Removed kmod-kvdo from content set for EL10

### DIFF
--- a/configs/sst_logical_storage-packages.yaml
+++ b/configs/sst_logical_storage-packages.yaml
@@ -47,17 +47,6 @@ data:
     - userspace-rcu
   # RHEL-specific packages, not available in Fedora
   package_placeholders:
-    - srpm_name: kmod-kvdo
-      build_dependencies:
-        - elfutils-libelf-devel
-        - kernel-devel
-        - libuuid-devel
-      rpms:
-        - rpm_name: kmod-kvdo
-          description: Kernel Modules for Virtual Data Optimizer
-          dependencies:
-            - kernel-core
-            - kernel-modules
     - srpm_name: vdo
       build_dependencies:
         - libblkid-devel


### PR DESCRIPTION
This functionality has been merged into the upstream kernel and is intended to be delivered in the same manner in the next major release.

Signed-off-by: Andrew Walsh <awalsh@redhat.com>