### PR TITLE
sst_bootc: Drop initoverlayfs

### DIFF
--- a/configs/sst_bootc-eln.yaml
+++ b/configs/sst_bootc-eln.yaml
@@ -9,7 +9,6 @@ data:
   packages:
     - bootc
     - composefs
-    - initoverlayfs
   labels:
     - eln
     - c9s


### PR DESCRIPTION
At the current time the development of this is focused on Auto primarily as far as I know and the composition of the current bootc SST does not maintain it.