### PR TITLE
Add libclc

### DIFF
--- a/configs/sst_gpu-OpenCL-infrastructure.yaml
+++ b/configs/sst_gpu-OpenCL-infrastructure.yaml
@@ -5,6 +5,7 @@ data:
   description: Even if we don't ship OpenCL itself, we need to ship the icd, headers and filesystem for vendor drivers
   maintainer: sst_gpu
   packages:
+    - libclc
     - ocl-icd
     - opencl-filesystem
     - opencl-headers


### PR DESCRIPTION
libclc is required to build Intel drivers with mesa >= 24.1.0

JIRA issue: https://issues.redhat.com/browse/RHELPLAN-170068