### PR TITLE
sst_csi_client_tools: add redhat-cloud-client-configuration

### DIFF
--- a/configs/sst_csi_client_tools.yaml
+++ b/configs/sst_csi_client_tools.yaml
@@ -47,6 +47,13 @@ data:
             - ansible-core
             - python3-PyYAML
             - python3-requests
+    - srpm_name: redhat-cloud-client-configuration
+      rpms:
+        - rpm_name: redhat-cloud-client-configuration
+          description: redhat-cloud-client-configuration
+          dependencies:
+            - subscription-manager
+            - systemd
   labels:
     - eln
     - c9s


### PR DESCRIPTION
This RHEL-only package exists already in 7, 8, and 9, and it was forgotten from 10. Hence, let's add it as placeholder package.