### PR TITLE
Separate repository for ELN Extras

### DIFF
--- a/configs/repository-fedora-eln-extras.yaml
+++ b/configs/repository-fedora-eln-extras.yaml
@@ -1,0 +1,110 @@
+---
+document: feedback-pipeline-repository
+version: 2
+data:
+  name: Fedora ELN Extras (backed by rawhide)
+  description: Fedora ELN Extras, based on Fedora ELN with rawhide as a backup for missing packages
+  maintainer: asamalik
+  source:
+    repos:
+      BaseOS:
+        baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/$basearch/os/
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        exclude: &eln_excludes
+        # ffmpeg is unwanted
+        - libav*-free
+        - libpostproc-free
+        - libswresample-free
+        - libswscale-free
+        # qtwebengine is unwanted
+        - qt6-qtpdf
+        - qt6-qtwebengine
+        priority: 1
+      AppStream:
+        baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/$basearch/os/
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        exclude: *eln_excludes
+        priority: 1
+      CRB:
+        baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/$basearch/os/
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        exclude: *eln_excludes
+        priority: 1
+      HA:
+        baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/HighAvailability/$basearch/os/
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        limit_arches: ["aarch64", "ppc64le", "s390x", "x86_64"]
+        priority: 2
+      NFV:
+        baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/NFV/$basearch/os/
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        limit_arches: ["x86_64"]
+        priority: 2
+      RT:
+        baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/RT/$basearch/os/
+        priority: 50
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        limit_arches: ["x86_64"]
+      RS:
+        baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/ResilientStorage/$basearch/os/
+        priority: 50
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        limit_arches: ["ppc64le", "s390x", "x86_64"]
+      SAP:
+        baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/SAP/$basearch/os/
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        limit_arches: ["ppc64le", "s390x", "x86_64"]
+        priority: 2
+      SAPHANA:
+        baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/SAPHANA/$basearch/os/
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        limit_arches: ["ppc64le", "x86_64"]
+        priority: 2
+      Extras:
+        baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/Extras/$basearch/os/
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        priority: 3
+      buildroot:
+        baseurl: https://kojipkgs.fedoraproject.org/repos/eln-build/latest/$basearch/
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        exclude: &eln_build_excludes
+        # prefer bind
+        - bind9-next*
+        # prefer postfix and sendmail
+        - esmtp
+        - esmtp-local-delivery
+        - exim
+        - opensmtpd
+        # RHEL packages are named ipa*
+        - freeipa*
+        # openjdk-portable packages are built against the oldest supported
+        # RHEL version, will not be imported into next RHEL version
+        - java-*-openjdk-portable*
+        # prefer grubby
+        - sdubby
+        priority: 4
+      Rawhide:
+        baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/$basearch/os/
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        exclude: *eln_build_excludes
+        priority: 5
+    releasever: "rawhide"
+    architectures:
+      - aarch64
+      - ppc64le
+      - s390x
+      - x86_64
+    composeinfo: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/metadata/composeinfo.json
+    base_buildroot_override: ['bash', 'bzip2', 'coreutils', 'cpio', 'diffutils', 'findutils', 'gawk', 'glibc-minimal-langpack', 'grep', 'gzip', 'info', 'make', 'patch', 'redhat-rpm-config', 'rpm-build', 'sed', 'shadow-utils', 'tar', 'unzip', 'util-linux', 'which', 'xz']

--- a/configs/view-eln-extras.yaml
+++ b/configs/view-eln-extras.yaml
@@ -8,6 +8,7 @@ data:
   labels:
   - eln-extras
   base_view_id: view-eln
+  repository: repository-fedora-eln-extras
 
   # Packages to be flagged as unwanted  on specific architectures
   #unwanted_arch_packages:


### PR DESCRIPTION
The packages we want to exclude from ELN might still belong in ELN Extras.