### PR TITLE
Update kde, qt6 and qt5 in eln_extras

### DIFF
--- a/configs/eln_extras_kde.yaml
+++ b/configs/eln_extras_kde.yaml
@@ -98,6 +98,7 @@ data:
     - kf6-attica
     - kf6-baloo
     - kf6-bluez-qt
+    - kf6-filesystem
     - kf6-frameworkintegration
     - kf6-kapidox
     - kf6-karchive
@@ -161,6 +162,7 @@ data:
     - kf6-prison
     - kf6-purpose
     - kf6-qqc2-desktop-style
+    - kf6-rpm-macros
     - kf6-solid
     - kf6-sonnet
     - kf6-syndication

--- a/configs/eln_extras_qt5.yaml
+++ b/configs/eln_extras_qt5.yaml
@@ -1,0 +1,43 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: qt5 eln-extra packages
+  description: QT5 ELN Extras packages
+  maintainer: tdawson
+  labels:
+    - eln-extras
+  packages:
+    - qt5-doc
+    - qt5-qt3d
+    - qt5-qtbase
+    - qt5-qtcharts
+    - qt5-qtconnectivity
+    - qt5-qtdatavis3d
+    - qt5-qtdeclarative
+    - qt5-qtdoc
+    - qt5-qtgamepad
+    - qt5-qtgraphicaleffects
+    - qt5-qtimageformats
+    - qt5-qtlocation
+    - qt5-qtmultimedia
+    - qt5-qtnetworkauth
+    - qt5-qtquickcontrols
+    - qt5-qtquickcontrols2
+    - qt5-qtremoteobjects
+    - qt5-qtscript
+    - qt5-qtscxml
+    - qt5-qtsensors
+    - qt5-qtserialbus
+    - qt5-qtserialport
+    - qt5-qtspeech
+    - qt5-qtsvg
+    - qt5-qttools
+    - qt5-qttranslations
+    - qt5-qtvirtualkeyboard
+    - qt5-qtwayland
+    - qt5-qtwebchannel
+    - qt5-qtwebsockets
+    - qt5-qtx11extras
+    - qt5-qtxmlpatterns
+    - qt5-rpm-macros
+    - qt5-srpm-macros

--- a/configs/eln_extras_qt6.yaml
+++ b/configs/eln_extras_qt6.yaml
@@ -6,12 +6,20 @@ data:
   maintainer: tdawson
   packages:
     - python3-pyqt6-charts
+    - qt6-doc
+    - qt6-qtcoap
+    - qt6-qtgraphs
+    - qt6-qtgrpc
+    - qt6-qthttpserver
+    - qt6-qtmqtt
+    - qt6-qtopcua
   labels:
     - eln-extras
   arch_packages:
     aarch64:
       - python3-pyqt6-webengine
       - qt6ct
+      - qt6-qtquick3dphysics
       - qt6-qtwebengine
       - qt6-qtwebengine-devtools
       - qt6-qtwebview
@@ -20,6 +28,7 @@ data:
     x86_64:
       - python3-pyqt6-webengine
       - qt6ct
+      - qt6-qtquick3dphysics
       - qt6-qtwebengine
       - qt6-qtwebengine-devtools
       - qt6-qtwebview


### PR DESCRIPTION
Updating KDE and qt6.
Adding qt5 packages.
  We will be supporting qt5 packages in epel10 as long as they are supported in RHEL9 and/or Fedora.