### PR TITLE
Revert "Add libclc"

### DIFF
--- a/configs/sst_gpu-OpenCL-infrastructure.yaml
+++ b/configs/sst_gpu-OpenCL-infrastructure.yaml
@@ -5,7 +5,6 @@ data:
   description: Even if we don't ship OpenCL itself, we need to ship the icd, headers and filesystem for vendor drivers
   maintainer: sst_gpu
   packages:
-    - libclc
     - ocl-icd
     - opencl-filesystem
     - opencl-headers


### PR DESCRIPTION
This reverts commit baf3898c851f960a19fcf8ec3877cf4d42cc980a.

It was decided to build libclc as part of mesa for the moment:

https://issues.redhat.com/browse/RHELPLAN-170071?focusedId=24850231&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24850231