### PR TITLE
Add more Python packages to c10s CRB workflow

### DIFF
--- a/configs/sst_cs_apps-python-crb-c10s.yaml
+++ b/configs/sst_cs_apps-python-crb-c10s.yaml
@@ -31,5 +31,11 @@ data:
     # rather than going trough a tad tedious process to add them after GA
     - python3-installer
     - python3-pyproject-hooks
+    # extras from packages in other Python workflows
+    - micropipenv+toml
+    - python3-jinja2+i18n
+    # packages we need as build dependencies only and are willingly maintaining them in CRB
+    - python3-testpath
+    - python-testpath-doc
   labels:
     - c10s


### PR DESCRIPTION
Those are intentionally not listed in the ELN workload,
as we do not want to pull them into ELN,
we just acknowledge them in CRB as they are already ours.


cc @frenzymadness @torsava