### PR TITLE
Drop i686 and armv7hl

### DIFF
--- a/configs/eln_extras_hyperscale.yaml
+++ b/configs/eln_extras_hyperscale.yaml
@@ -24,8 +24,6 @@ data:
   arch_packages:
     x86_64:
       - systemd-boot-unsigned
-    i686:
-      - systemd-boot-unsigned
     aarch64:
       - systemd-boot-unsigned
   labels:

--- a/configs/repository-fedora-rawhide.yaml
+++ b/configs/repository-fedora-rawhide.yaml
@@ -37,7 +37,6 @@ data:
     releasever: "rawhide"
     architectures:
       - aarch64
-      - i686
       - ppc64le
       - s390x
       - x86_64

--- a/configs/sst_cs_infra_services-development-packages-c9s.yaml
+++ b/configs/sst_cs_infra_services-development-packages-c9s.yaml
@@ -51,9 +51,6 @@ data:
     # urw-base35-fonts
     - urw-base35-fonts-devel
   arch_packages:
-    armv7hl:
-      # i2c-tools (ExcludeArch: s390 s390x)
-      - libi2c-devel
     aarch64:
       # i2c-tools (ExcludeArch: s390 s390x)
       - libi2c-devel

--- a/configs/sst_cs_infra_services-development-packages.yaml
+++ b/configs/sst_cs_infra_services-development-packages.yaml
@@ -49,9 +49,6 @@ data:
     # urw-base35-fonts
     - urw-base35-fonts-devel
   arch_packages:
-    armv7hl:
-      # i2c-tools (ExcludeArch: s390 s390x)
-      - libi2c-devel
     aarch64:
       # i2c-tools (ExcludeArch: s390 s390x)
       - libi2c-devel

--- a/configs/sst_cs_infra_services-i2c-tools.yaml
+++ b/configs/sst_cs_infra_services-i2c-tools.yaml
@@ -6,12 +6,6 @@ data:
   maintainer: sst_cs_infra_services
   packages: []
   arch_packages:
-    armv7hl:
-      # i2c-tools (ExcludeArch: s390 s390x)
-      - i2c-tools
-      - i2c-tools-perl
-      - libi2c
-      - python3-i2c-tools
     aarch64:
       # i2c-tools (ExcludeArch: s390 s390x)
       - i2c-tools

--- a/configs/sst_cs_infra_services-power-management.yaml
+++ b/configs/sst_cs_infra_services-power-management.yaml
@@ -7,9 +7,6 @@ data:
   packages:
     - powertop
   arch_packages:
-    armv7hl:
-      # acpid (ExclusiveArch: ia64 x86_64 %{ix86} %{arm} aarch64)
-      - acpid
     aarch64:
       # acpid (ExclusiveArch: ia64 x86_64 %{ix86} %{arm} aarch64)
       - acpid

--- a/configs/sst_cs_plumbers-hw-tools.yaml
+++ b/configs/sst_cs_plumbers-hw-tools.yaml
@@ -15,8 +15,6 @@ data:
   arch_packages:
     x86_64:
       - biosdevname
-    i686:
-      - biosdevname
   labels:
     - eln
     - c10s

--- a/configs/sst_cs_system_management-sys-management-c9s.yaml
+++ b/configs/sst_cs_system_management-sys-management-c9s.yaml
@@ -87,8 +87,6 @@ data:
     #setserial not supported on s390x
     aarch64:
       - setserial
-    i686:
-      - setserial
     x86_64:
       - setserial
     ppc64le:

--- a/configs/sst_cs_system_management-sys-management.yaml
+++ b/configs/sst_cs_system_management-sys-management.yaml
@@ -82,8 +82,6 @@ data:
     #setserial not supported on s390x
     aarch64:
       - setserial
-    i686:
-      - setserial
     x86_64:
       - setserial
     ppc64le:

--- a/configs/sst_desktop_firmware_bootloaders-efibootmgr.yaml
+++ b/configs/sst_desktop_firmware_bootloaders-efibootmgr.yaml
@@ -10,8 +10,6 @@ data:
     - c9s
     - c10s
   arch_packages:
-    armv7hl:
-      - efibootmgr
     aarch64:
       - efibootmgr
     x86_64:

--- a/configs/sst_desktop_firmware_bootloaders-efivar.yaml
+++ b/configs/sst_desktop_firmware_bootloaders-efivar.yaml
@@ -10,8 +10,6 @@ data:
     - c9s
     - c10s
   arch_packages:
-    armv7hl:
-      - efivar
     aarch64:
       - efivar
     x86_64:

--- a/configs/sst_desktop_firmware_bootloaders-gnu-efi.yaml
+++ b/configs/sst_desktop_firmware_bootloaders-gnu-efi.yaml
@@ -10,8 +10,6 @@ data:
     - c9s
     - c10s
   arch_packages:
-    armv7hl:
-      - gnu-efi
     aarch64:
       - gnu-efi
     x86_64:

--- a/configs/sst_desktop_firmware_bootloaders-os-prober.yaml
+++ b/configs/sst_desktop_firmware_bootloaders-os-prober.yaml
@@ -10,8 +10,6 @@ data:
     - c9s
     - c10s
   arch_packages:
-    armv7hl:
-      - os-prober
     aarch64:
       - os-prober
     ppc64le:

--- a/configs/sst_desktop_firmware_bootloaders-pesign.yaml
+++ b/configs/sst_desktop_firmware_bootloaders-pesign.yaml
@@ -10,8 +10,6 @@ data:
     - c9s
     - c10s
   arch_packages:
-    armv7hl:
-      - pesign
     aarch64:
       - pesign
     x86_64:

--- a/configs/sst_desktop_platform_technologies-gnome-desktop-eln.yaml
+++ b/configs/sst_desktop_platform_technologies-gnome-desktop-eln.yaml
@@ -14,9 +14,6 @@ data:
     - eln
     - c10s
   arch_packages:
-    armv7hl:
-      - fprintd
-      - fprintd-pam
     aarch64:
       - fprintd
       - fprintd-pam

--- a/configs/sst_desktop_platform_technologies-gnome-desktop.yaml
+++ b/configs/sst_desktop_platform_technologies-gnome-desktop.yaml
@@ -14,9 +14,6 @@ data:
   labels:
     - c9s
   arch_packages:
-    armv7hl:
-      - fprintd
-      - fprintd-pam
     aarch64:
       - fprintd
       - fprintd-pam

--- a/configs/sst_network_drivers-appstream-c9s.yaml
+++ b/configs/sst_network_drivers-appstream-c9s.yaml
@@ -17,15 +17,6 @@ data:
     - mpich-devel
     - mpich-doc
     - python3-mpich
+    - opensm-devel
   labels:
     - c9s
-  arch_packages:
-    # not armv7hl
-    aarch64:
-      - opensm-devel
-    ppc64le:
-      - opensm-devel
-    s390x:
-      - opensm-devel
-    x86_64:
-      - opensm-devel

--- a/configs/sst_network_drivers-appstream.yaml
+++ b/configs/sst_network_drivers-appstream.yaml
@@ -17,16 +17,7 @@ data:
     - mpich-devel
     - mpich-doc
     - python3-mpich
+    - opensm-devel
   labels:
     - eln
     - c10s
-  arch_packages:
-    # not armv7hl
-    aarch64:
-      - opensm-devel
-    ppc64le:
-      - opensm-devel
-    s390x:
-      - opensm-devel
-    x86_64:
-      - opensm-devel

--- a/configs/sst_network_drivers-baseos.yaml
+++ b/configs/sst_network_drivers-baseos.yaml
@@ -6,73 +6,22 @@ data:
   maintainer: sst_network_drivers
   packages:
     - libfabric
+    - libibverbs
+    - libibverbs-utils
+    - librdmacm
+    - librdmacm-utils
+    - rdma-core
+    - ibacm
+    - infiniband-diags
+    - iwpmd
+    - libibumad
+    - srp_daemon
+    - rdma-core-devel
+    - python3-pyverbs
+    - opensm
+    - opensm-libs
+    - perftest
   labels:
     - eln
     - c9s
     - c10s
-  arch_packages:
-    # not armv7hl
-    aarch64:
-      - libibverbs
-      - libibverbs-utils
-      - librdmacm
-      - librdmacm-utils
-      - rdma-core
-      - ibacm
-      - infiniband-diags
-      - iwpmd
-      - libibumad
-      - srp_daemon
-      - rdma-core-devel
-      - python3-pyverbs
-      - opensm
-      - opensm-libs
-      - perftest
-    ppc64le:
-      - libibverbs
-      - libibverbs-utils
-      - librdmacm
-      - librdmacm-utils
-      - rdma-core
-      - ibacm
-      - infiniband-diags
-      - iwpmd
-      - libibumad
-      - srp_daemon
-      - rdma-core-devel
-      - python3-pyverbs
-      - opensm
-      - opensm-libs
-      - perftest
-    s390x:
-      - libibverbs
-      - libibverbs-utils
-      - librdmacm
-      - librdmacm-utils
-      - rdma-core
-      - ibacm
-      - infiniband-diags
-      - iwpmd
-      - libibumad
-      - srp_daemon
-      - rdma-core-devel
-      - python3-pyverbs
-      - opensm
-      - opensm-libs
-      - perftest
-    x86_64:
-      - libibverbs
-      - libibverbs-utils
-      - librdmacm
-      - librdmacm-utils
-      - rdma-core
-      - ibacm
-      - infiniband-diags
-      - iwpmd
-      - libibumad
-      - srp_daemon
-      - rdma-core-devel
-      - python3-pyverbs
-      - opensm
-      - opensm-libs
-      - perftest

--- a/configs/sst_pt_gcc-gcc-toolset.yaml
+++ b/configs/sst_pt_gcc-gcc-toolset.yaml
@@ -29,9 +29,6 @@ data:
     aarch64:
       - liblsan
       - libtsan
-    i686:
-      - libquadmath
-      - libquadmath-devel
     ppc64le:
       - gcc-offload-nvptx
       - libgomp-offload-nvptx

--- a/configs/sst_pt_llvm_rust_go-llvm-toolset-c9s.yaml
+++ b/configs/sst_pt_llvm_rust_go-llvm-toolset-c9s.yaml
@@ -45,9 +45,5 @@ data:
       - lld
       - lld-devel
       - lld-libs
-    armv7hl:
-      - libomp
-      - libomp-devel
-      - libomp-test
   labels:
     - c9s

--- a/configs/sst_pt_perf_debug-debuggers-unwanted.yaml
+++ b/configs/sst_pt_perf_debug-debuggers-unwanted.yaml
@@ -6,9 +6,6 @@ data:
   maintainer: sst_pt_perf_debug
   unwanted_packages:
     - babeltrace
-  unwanted_arch_packages:
-    i686:
-      - gdb-minimal
   labels:
     - eln
     - c9s

--- a/configs/sst_pt_perf_debug-debuggers.yaml
+++ b/configs/sst_pt_perf_debug-debuggers.yaml
@@ -9,6 +9,7 @@ data:
     - gdb-doc
     - gdb-gdbserver
     - gdb-headless
+    - gdb-minimal
     - libbabeltrace
     - libbabeltrace-devel
     - source-highlight
@@ -18,18 +19,7 @@ data:
     - c9s
     - c10s
   # libipt is Intel only
-  # gdb-minimal is supported on everything but i686
   arch_packages:
-    aarch64:
-      - gdb-minimal
-    i686:
-      - libipt
-      - libipt-devel
-    ppc64le:
-      - gdb-minimal
-    s390x:
-      - gdb-minimal
     x86_64:
       - libipt
       - libipt-devel
-      - gdb-minimal

--- a/configs/sst_pt_perf_debug-performance-tools.yaml
+++ b/configs/sst_pt_perf_debug-performance-tools.yaml
@@ -47,15 +47,6 @@ data:
       - papi-devel
       - papi-libs
       - papi-testsuite
-    i686:
-      - dyninst
-      - dyninst-devel
-      - dyninst-doc
-      - dyninst-testsuite
-      - papi
-      - papi-devel
-      - papi-libs
-      - papi-testsuite
     ppc64le:
       - dyninst
       - dyninst-devel


### PR DESCRIPTION
C10S and ELN are dropping all i686 builds, and even in C9S i686 was built only for multilibs and not separately composed.  32-bit ARM was never a supported platform in RHEL or CentOS Stream.

/cc @tdawson @sgallagher 