### PR TITLE
Drop marshalparser from the Python CRB ELN workload

### DIFF
--- a/configs/sst_cs_apps-python-crb-eln.yaml
+++ b/configs/sst_cs_apps-python-crb-eln.yaml
@@ -24,7 +24,6 @@ data:
     - python3-psutil-tests
     - py3c-devel
     - py3c-doc
-    - marshalparser
     - python3-hatchling
     # the following packages are anticipated to be used by pyproject-rpm-macros
     # in the feature, so we want them in CRB early,


### PR DESCRIPTION
It is no longer necessary in RHEL 11+ due to
https://fedoraproject.org/wiki/Changes/ReproduciblePackageBuilds

See also https://pagure.io/packaging-committee/pull-request/1371

cc @frenzymadness @torsava @keszybz 