### PR TITLE
Update rust packages for RHEL 10

### DIFF
--- a/configs/sst_pt_llvm_rust_go-rust-toolset-c9s.yaml
+++ b/configs/sst_pt_llvm_rust_go-rust-toolset-c9s.yaml
@@ -12,8 +12,7 @@ data:
     - rust-doc
     - rust-std-static
     - rustfmt
-    - rust-toolset-srpm-macros
+    - rust-srpm-macros
     - rust-toolset
   labels:
-    - eln
-    - c10s
+    - c9s


### PR DESCRIPTION
The srpm-macros subpackage needed to be renamed to provide a clean upgrade path from RHEL 9: https://src.fedoraproject.org/rpms/rust/c/230ae0c65c9c719221d668037e4400bdeac9ee40

/cc @cuviper 