### PR TITLE
Bring pcs dependenies up to date

### DIFF
--- a/configs/sst_high_availability-userspace.yaml
+++ b/configs/sst_high_availability-userspace.yaml
@@ -164,27 +164,34 @@ data:
             - x86_64
     - srpm_name: pcs
       build_dependencies:
+        - autoconf
+        - automake
         - booth
+        - coreutils
         - corosync-qdevice-devel
         - corosynclib-devel
         - diffstat
-        # fence-agents-common (placeholder)
+        - gcc
+        - gcc-c++
         - git-core
+        - libappstream-glib
+        - libcurl-devel
         - make
-        - npm
+        - nodejs-npm
+        - nss-tools
+        - openssl-devel
         - pacemaker-libs-devel
         - pam
+        - python3
         - python3-cryptography
         - python3-dateutil
         - python3-devel
-        - python3-setuptools
+        - python3-lxml
         - python3-pip
         - python3-pyparsing
-        - python3-lxml
+        - python3-setuptools
         - python3-wheel
-        - python3-setuptools_scm
-        - redhat-logos
-        - resource-agents
+        - ruby
         - ruby-devel
         - rubygems
         - rubygem-bundler
@@ -192,6 +199,7 @@ data:
         - rubygem-rexml
         - rubygem-test-unit
         - sbd
+        - systemd
       limit_arches:
         - x86_64
         - ppc64le
@@ -201,7 +209,10 @@ data:
           description: Built with bundled dependencies in RHEL
           dependencies:
             - corosync
+            - libcurl
             - libknet1-plugins-all
+            - logrotate
+            - nss-tools
             - pacemaker-cli
             - pam
             - pcmk-cluster-manager
@@ -212,7 +223,6 @@ data:
             - python3-lxml
             - python3-pyparsing
             - python3-setuptools
-            - redhat-logos
             - ruby
             - rubygem-json
             - rubygem-rexml


### PR DESCRIPTION
This PR contains the up-to-date 1:1 mapping to Requires and BuildRequires in pcs spec file. I noticed that nobody updated the dependencies here since pcs became a placeholder. So I came to the conclusion that I, as a maintainer, should keep them up to date also here. I don't know how many placeholders exist, but I think that it would be nice to remind other maintainers that they should update their dependencies too. 

I switched to requiring virtual provides for pkgconfig in pcs spec file where possible. I suppose that Content Resolver doesn't support resolving that, so I left those dependencies as they were before.

I noticed that some dependencies were missing completely, like python or ruby for the srpm. Also, gcc and gcc-c++ were missing, these are needed for compiling python module and rubygem extensions. Maybe this was intentional, feel free to remove them, but I wanted to map the dependencies 1:1 to the spec file.