### PR TITLE
Drop docbook5-schemas

### DIFF
--- a/configs/sst_cs_system_management-text-processing.yaml
+++ b/configs/sst_cs_system_management-text-processing.yaml
@@ -9,7 +9,6 @@ data:
     - asciidoc-doc
     - docbook-style-dsssl
     - docbook-utils
-    - docbook5-schemas
     - doxygen
     - doxygen-latex
     - help2man

--- a/configs/sst_cs_system_management-unwanted.yaml
+++ b/configs/sst_cs_system_management-unwanted.yaml
@@ -69,6 +69,7 @@ data:
     - bacula-client
     - bacula-console
     - udftools
+    - docbook5-schemas
   labels:
     - eln
     - c10s


### PR DESCRIPTION
Due to a licensing issue, we are dropping the docbook5-schemas support from RHEL. This is a test to see if that is a possibility or if it is still a hard requirement.

Related: RHELMISC-5885, BZ#2260534