### PR TITLE
Remove udftools from C10S and ELN

### DIFF
--- a/configs/sst_cs_system_management-sys-management.yaml
+++ b/configs/sst_cs_system_management-sys-management.yaml
@@ -60,7 +60,6 @@ data:
     - tesseract-tessdata-doc
     - tmpwatch
     - tracer
-    - udftools
     - usermode
     - uuid
     - uuid-devel

--- a/configs/sst_cs_system_management-unwanted.yaml
+++ b/configs/sst_cs_system_management-unwanted.yaml
@@ -68,6 +68,7 @@ data:
     - openslp-server
     - bacula-client
     - bacula-console
+    - udftools
   labels:
     - eln
     - c10s


### PR DESCRIPTION
We decided to keep it in EPEL due to its low usage.

This reverts part of commit e3c186bcce96e21aa8bf8805d9d889b68187d361