### PR TITLE
Drop libreport

### DIFF
--- a/configs/sst_program-lorax-template.yaml
+++ b/configs/sst_program-lorax-template.yaml
@@ -70,8 +70,6 @@ data:
     - default-fonts-other-sans
     - google-noto-sans-cjk-fonts
     - gdb-gdbserver
-    - libreport-plugin-bugzilla
-    - libreport-plugin-reportuploader
     - python3-pyatspi
     - vim-minimal
     - strace

--- a/configs/sst_security_crypto-unwanted.yaml
+++ b/configs/sst_security_crypto-unwanted.yaml
@@ -22,6 +22,8 @@ data:
     - python2-crypto
     # OpenSSL 3 deprecated engines, use the openssl pkcs11 provider instead
     - openssl-pkcs11
+    # Deprecated OpenSSL components
+    - openssl-devel-engine
   labels:
     - eln
     - c10s


### PR DESCRIPTION
libreport is being removed from RHEL 10:

https://gitlab.com/redhat/centos-stream/rpms/lorax-templates-rhel/-/merge_requests/51
https://src.fedoraproject.org/rpms/lorax-templates-rhel/pull-request/10