### PR TITLE
Remove open-sans-fonts package from Extra fonts workload

### DIFF
--- a/configs/sst_i18n-extra-fonts.yaml
+++ b/configs/sst_i18n-extra-fonts.yaml
@@ -69,7 +69,6 @@ data:
     - langpacks-fonts-zu
     - lato-fonts
     - liberation-narrow-fonts
-    - open-sans-fonts
   labels:
     - eln
     - c10s


### PR DESCRIPTION
The sst_i18n team found that they have ownership entry for open-sans-fonts package ownership but no other sst_i18n package needs that font package.
Hence, we would like to remove it from Extra Fonts workload.

The open-sans-fonts package is already required by ssg_idm team in their 3 workloads.