### PR TITLE
Update nodejs workload

### DIFF
--- a/configs/sst_cs_apps-nodejs.yaml
+++ b/configs/sst_cs_apps-nodejs.yaml
@@ -1,13 +1,13 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: Node.js runtime
-  description: Node.js (Javascript) runtime and NPM installer for appliechoion development
+  name: Node.js runtime – default stream
+  description: Node.js (Javascript) runtime and NPM installer for application development
   maintainer: sst_cs_apps
   packages:
     - nodejs
     - nodejs-devel
-    - npm
+    - nodejs-npm
     - nodejs-nodemon
   labels:
     - eln


### PR DESCRIPTION
In reaction of packaging changes in Fedora (soon to be in RHEL).

- Clarify this is for the default NodeJS stream; other streams' packages will be named nodejsXY-<pkg>
- Rename npm to nodejs-npm
- Fix typo

---

I also have a few questions I would like to clarify:

1. For the future alternative streams (i.e. nodejs22, nodejs24, …), should new workload be created? These should be independent of one another (parallel installable), so I'm assuming that they should.
2. The "default" packages can be generated from different SRPMs based on which macros are set. (I.e. `nodejs20` SRPM currently produces `nodejs`, `nodejs-npm`, … packages, but can suddently start producing `nodejs20`, `nodejs20-npm`, …) Is this something I should somehow inform content resolver about, or it does not care and simply deals with binary rpm names no matter which SRPM they come from?
3. Can I submit workload for "nonexistent" RPMs? (In preparation for the name change described above, for example.)