### PR TITLE
Add open-vm-tools and hyperv-daemons for aarch64

### DIFF
--- a/configs/sst_virtualization_cloud-3rdparty_hypervisors.yaml
+++ b/configs/sst_virtualization_cloud-3rdparty_hypervisors.yaml
@@ -6,6 +6,14 @@ data:
   maintainer: sst_virtualization_cloud
   packages: []
   arch_packages:
+    aarch64:
+      - open-vm-tools
+      - open-vm-tools-desktop
+      - open-vm-tools-test
+      - hyperv-daemons
+      - hyperv-tools
+      - hypervkvpd
+      - hypervvssd
     x86_64:
       - open-vm-tools
       - open-vm-tools-desktop


### PR DESCRIPTION
These are now being built and shipped for aarch64, except for open-vm-tools-sdmp and hypervfcopyd.

/cc @LaneWolf 