### PR TITLE
Replacing wget2 with wget in RHEL10

### DIFF
--- a/configs/sst_cs_infra_services-http-ftp-cli-clients-c10s.yaml
+++ b/configs/sst_cs_infra_services-http-ftp-cli-clients-c10s.yaml
@@ -7,6 +7,6 @@ data:
   packages:
     - ftp
     - lftp
-    - wget2-wget
+    - wget
   labels:
-    - eln
+    - c10s


### PR DESCRIPTION
wget2 is not ready to be deployed in RHEL10 so we are replacing it with the original wget.