### PR TITLE
Remove qt6-qtbase-private-devel as it should be shipped in CRB

### DIFF
--- a/configs/sst_desktop_applications-qt6.yaml
+++ b/configs/sst_desktop_applications-qt6.yaml
@@ -24,7 +24,6 @@ data:
     - qt6-qtbase-mysql
     - qt6-qtbase-odbc
     - qt6-qtbase-postgresql
-    - qt6-qtbase-private-devel
     - qt6-qtbase-static
     - qt6-qtcharts
     - qt6-qtcharts-devel


### PR DESCRIPTION
And being specified here makes it go into AppStream