### PR TITLE
Drop redis from ELN

### DIFF
--- a/configs/sst_cs_infra_services-redis.yaml
+++ b/configs/sst_cs_infra_services-redis.yaml
@@ -9,5 +9,4 @@ data:
     - redis-doc
     - redis-devel
   labels:
-    - eln
     - c10s


### PR DESCRIPTION
redis has been retired from F41:  https://fedoraproject.org/wiki/Changes/Replace_Redis_With_Valkey

/cc @notroj 