### PR TITLE
Add sst_cs_apps-java-bootstrap workload

### DIFF
--- a/configs/sst_cs_apps-java-bootstrap.yaml
+++ b/configs/sst_cs_apps-java-bootstrap.yaml
@@ -1,0 +1,15 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Bootstrap environment for Java packages
+  description: |
+    Buildroot-only packages required to build Java packages in
+    bootstrap mode.  Not pulled-in via dependency resolution because
+    in normal conditions bootstrapping is disabled, so RPM
+    dependencies on bootstrap packages are absent.
+  maintainer: sst_cs_apps
+  packages:
+    - javapackages-bootstrap
+  labels:
+    - eln
+    - c10s


### PR DESCRIPTION
Add workload with buildroot-only packages required to build Java packages in bootstrap mode.

These need to be pulled into ELN/C10S explicitly because in normal conditions bootstrapping is disabled, so RPM dependencies on bootstrap packages are absent, and bootstrap packages are not pulled-in by Content Resolver via dependency resolution mechanism.