### PR TITLE
Reduce filtering in eln-extras repo

### DIFF
--- a/configs/repository-fedora-eln-extras.yaml
+++ b/configs/repository-fedora-eln-extras.yaml
@@ -11,27 +11,16 @@ data:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: &eln_excludes
-        # ffmpeg is unwanted
-        - libav*-free
-        - libpostproc-free
-        - libswresample-free
-        - libswscale-free
-        # qtwebengine is unwanted
-        - qt6-qtpdf
-        - qt6-qtwebengine
         priority: 1
       AppStream:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: *eln_excludes
         priority: 1
       CRB:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
-        exclude: *eln_excludes
         priority: 1
       HA:
         baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/HighAvailability/$basearch/os/
@@ -81,11 +70,6 @@ data:
         exclude: &eln_build_excludes
         # prefer bind
         - bind9-next*
-        # prefer postfix and sendmail
-        - esmtp
-        - esmtp-local-delivery
-        - exim
-        - opensmtpd
         # RHEL packages are named ipa*
         - freeipa*
         # openjdk-portable packages are built against the oldest supported


### PR DESCRIPTION
ELN repos are not always completely clean of Extras content.  Also, those packages which provide an alternative implementation to certain components in RHEL are acceptable for Extras if they do not conflict.