### PR TITLE
coreos: bootupd is on all architectures

### DIFF
--- a/configs/sst_coreos.yaml
+++ b/configs/sst_coreos.yaml
@@ -9,6 +9,7 @@ data:
   packages:
     - afterburn
     - afterburn-dracut
+    - bootupd
     - butane
     - console-login-helper-messages-issuegen
     - console-login-helper-messages-motdgen
@@ -23,13 +24,6 @@ data:
     - coreos-installer
     - coreos-installer-bootinfra
     - coreos-installer-dracut
-  arch_packages:
-    x86_64:
-      - bootupd
-    aarch64:
-      - bootupd
-    ppc64le:
-      - bootupd
   labels:
     - eln
     - c10s


### PR DESCRIPTION
xref https://gitlab.com/redhat/centos-stream/release-engineering/pungi-centos/-/merge_requests/537 too