### PR TITLE
Fix arches of kaidan and plasma-nm-l2tp

### DIFF
--- a/configs/eln_extras_kde.yaml
+++ b/configs/eln_extras_kde.yaml
@@ -46,7 +46,6 @@ data:
     - juk
     - kaccounts-integration-qt6
     - kactivitymanagerd
-    - kaidan
     - kajongg
     - kalk
     - kalm
@@ -337,7 +336,6 @@ data:
     - plasma-nm
     - plasma-nm-fortisslvpn
     - plasma-nm-iodine
-    - plasma-nm-l2tp
     - plasma-nm-openswan
     - plasma-nm-openvpn
     - plasma-nm-pptp
@@ -412,6 +410,7 @@ data:
       - kaccounts-providers
       - kaddressbook
       - kaddressbook-libs
+      - kaidan
       - kalarm
       - kalgebra
       - kdepim-addons
@@ -439,6 +438,7 @@ data:
       - pim-data-exporter
       - pim-data-exporter-libs
       - pim-sieve-editor
+      - plasma-nm-l2tp
       - plasma-nm-openconnect
       - plasma-sdk
       - skanpage
@@ -463,6 +463,7 @@ data:
       - kaccounts-providers
       - kaddressbook
       - kaddressbook-libs
+      - kaidan
       - kalarm
       - kalgebra
       - kdepim-addons
@@ -490,7 +491,10 @@ data:
       - pim-data-exporter
       - pim-data-exporter-libs
       - pim-sieve-editor
+      - plasma-nm-l2tp
       - plasma-nm-openconnect
       - plasma-sdk
       - skanpage
       - tokodon
+    ppc64le:
+      - plasma-nm-l2tp


### PR DESCRIPTION
kaidan depends on qtwebengine.  plasma-nm-l2tp transitively depends on xl2tpd which requires kmod(l2tp_ppp.ko), which is not included in the RHEL kernel for s390x.

/cc @tdawson 