### PR TITLE
Add sil-nuosu-fonts package to extra fonts

### DIFF
--- a/configs/sst_i18n-extra-fonts.yaml
+++ b/configs/sst_i18n-extra-fonts.yaml
@@ -69,6 +69,7 @@ data:
     - langpacks-fonts-zu
     - lato-fonts
     - liberation-narrow-fonts
+    - sil-nuosu-fonts
   labels:
     - eln
     - c10s


### PR DESCRIPTION
We plan to include the sil-nuosu-fonts package in RHEL 10 for compatibility.