### PR TITLE
Drop zram-generator-defaults from base

### DIFF
--- a/configs/sst_cs_plumbers-base.yaml
+++ b/configs/sst_cs_plumbers-base.yaml
@@ -27,7 +27,6 @@ data:
     - systemd-udev
     - polkit
     - zram-generator
-    - zram-generator-defaults
   labels:
     - eln
     - c10s


### PR DESCRIPTION
Enabling swap-on-zram must be explicit action carried out by the admin. To prevent accidental enablement let's drop the package which ships default configuration. We have an example config in the main package so enabling it is still very easy.

This change makes zram setup in ELN and C10s same as it is C9s.