### PR TITLE
Remove catch1-devel from usbguard

### DIFF
--- a/configs/sst_security_special_projects-usbguard.yaml
+++ b/configs/sst_security_special_projects-usbguard.yaml
@@ -5,7 +5,6 @@ data:
   description: Enforcing USB security policy
   maintainer: sst_security_special_projects
   packages:
-    - catch1-devel
     - usbguard
     - usbguard-dbus
     - usbguard-notifier


### PR DESCRIPTION
catch1 is a C++-native, test framework for unit-tests. The usbguard component is not strictly dependant on the catch1 development files. We purely use it for some very basic testing purposes, mostly upstream but we have it enabled downstream as well. We could remove it any time and usbguard would be still properly functioning. 