### PR TITLE
Remove reference of compat-locales-sap and compat-locales-sap-common packages

### DIFF
--- a/configs/sst_sap.yaml
+++ b/configs/sst_sap.yaml
@@ -76,22 +76,6 @@ data:
           limit_arches:
             - x86_64
             - ppc64le
-    - srpm_name: compat-locales-sap
-      rpms:
-        - rpm_name: compat-locales-sap-common
-          description: locales for SAP
-          dependencies: []
-          limit_arches:
-            - x86_64
-            - ppc64le
-            - s390x
-        - rpm_name: compat-locales-sap
-          description: locales for SAP
-          dependencies: []
-          limit_arches:
-            - x86_64
-            - ppc64le
-            - s390x
   labels:
     - eln
     - c10s


### PR DESCRIPTION
SAP team decided that compat-locales-sap and compat-locales-sap-common packages will NOT be present in RHEL 10.

