### PR TITLE
Snapshot, Loupe and Brasero are not shipped on s390x/aarch64

### DIFF
--- a/configs/sst_desktop-brasero.yaml
+++ b/configs/sst_desktop-brasero.yaml
@@ -4,10 +4,16 @@ data:
   name: Brasero
   description: Default physical media burner application in Workstation
   maintainer: sst_desktop
-  packages:
-    - brasero
-    # Disabled until https://gitlab.gnome.org/GNOME/brasero/-/merge_requests/21 is merged
-    # - brasero-nautilus
+  packages: []
+  arch_packages:
+    ppc64le:
+      - brasero
+      # Disabled until https://gitlab.gnome.org/GNOME/brasero/-/merge_requests/21 is merged
+      # - brasero-nautilus
+    x86_64:
+      - brasero
+      # Disabled until https://gitlab.gnome.org/GNOME/brasero/-/merge_requests/21 is merged
+      # - brasero-nautilus
   labels:
     - eln
     - c10s

--- a/configs/sst_desktop-loupe.yaml
+++ b/configs/sst_desktop-loupe.yaml
@@ -4,9 +4,14 @@ data:
   name: Loupe
   description: Default image viewer for Workstation
   maintainer: sst_desktop
-  packages:
-    - loupe
-    - glycin-loaders
+  packages: []
+  arch_packages:
+    ppc64le:
+      - loupe
+      - glycin-loaders
+    x86_64:
+      - loupe
+      - glycin-loaders
   labels:
     - eln
     - c10s

--- a/configs/sst_desktop-snapshot.yaml
+++ b/configs/sst_desktop-snapshot.yaml
@@ -4,8 +4,12 @@ data:
   name: Snapshot
   description: Default application for handling webcams in Workstation
   maintainer: sst_desktop
-  packages:
-    - snapshot
+  packages: []
+  arch_packages:
+    ppc64le:
+      - snapshot
+    x86_64:
+      - snapshot
   labels:
     - eln
     - c10s


### PR DESCRIPTION
Reflect that status quo from RHEL 8+ here as well