### PR TITLE
Make the dependencies of postgresql-jdbc wanted.

### DIFF
--- a/configs/sst_cs_apps-unwanted-java.yaml
+++ b/configs/sst_cs_apps-unwanted-java.yaml
@@ -6,13 +6,11 @@ data:
   maintainer: sst_cs_apps
   unwanted_source_packages:
     - ant-contrib
-    - apache-commons-exec
     - apache-commons-lang
     - apache-ivy
     - bsh
     - cal10n
     - dom4j
-    - exec-maven-plugin
     - forge-parent
     - hamcrest2
     - hsqldb


### PR DESCRIPTION
postgresql-jdbc depends on ongres-stringprep which depends on exec-maven-plugin which depends on apache-comons-exec.