### PR TITLE
Drop Qt5WebEngine dependent packages from Extras

### DIFF
--- a/configs/eln_extras_kde.yaml
+++ b/configs/eln_extras_kde.yaml
@@ -398,7 +398,7 @@ data:
       - angelfish
       - arianna
       - bluedevil
-      - cantor
+      #- cantor
       - digikam
       - digikam-libs
       - falkon
@@ -410,7 +410,7 @@ data:
       - kaccounts-providers
       - kaddressbook
       - kaddressbook-libs
-      - kaidan
+      #- kaidan
       - kalarm
       - kalgebra
       - kdepim-addons
@@ -452,7 +452,7 @@ data:
       - angelfish
       - arianna
       - bluedevil
-      - cantor
+      #- cantor
       - digikam
       - digikam-libs
       - falkon
@@ -464,7 +464,7 @@ data:
       - kaccounts-providers
       - kaddressbook
       - kaddressbook-libs
-      - kaidan
+      #- kaidan
       - kalarm
       - kalgebra
       - kdepim-addons


### PR DESCRIPTION
While Qt5 is planned for EPEL 10, its WebEngine component is not.  cantor and kaidan show no signs of being close to Qt6 conversion, so this disables them in the meantime.  ghostwriter will move to Qt6 in 24.08, and marble's usage is optional and can be disabled in spec.

FWIW Qt5WebKit is even more unwanted, but so far the only dependents are kexi/kreport (which is about to be disabled in spec) and kdevelop (which is also moving to Qt6 in 24.08).

/cc @tdawson 