### PR TITLE
sst_container_tools: Add composefs

### DIFF
--- a/configs/sst_container_tools.yaml
+++ b/configs/sst_container_tools.yaml
@@ -11,6 +11,7 @@ data:
     - buildah
     - catatonit
     - cockpit-podman
+    - composefs
     - container-selinux
     - containers-common
     - conmon


### PR DESCRIPTION
Moving this here from https://github.com/containers/podman/pull/23588

---

xref https://issues.redhat.com/browse/RHELMISC-4891

And earlier: https://issues.redhat.com/browse/RHEL-18157

Basically the decision earlier was this was owned by the container_tools SST.