### PR TITLE
Drop xxhash package from RHEL10

### DIFF
--- a/configs/sst_kernel_security-intel-qat.yaml
+++ b/configs/sst_kernel_security-intel-qat.yaml
@@ -14,10 +14,6 @@ data:
       - qatzip
       - qatzip-devel
       - qatzip-libs
-      - xxhash
-      - xxhash-devel
-      - xxhash-doc
-      - xxhash-libs
   labels:
     - eln
     - c10s


### PR DESCRIPTION
xxhash is not required by any of QAT packages.
dwz and rsync have dropped xxhash requirement too.