### PR TITLE
Do not mark libdbusmenu as unwanted

### DIFF
--- a/configs/sst_desktop_applications-unwanted.yaml
+++ b/configs/sst_desktop_applications-unwanted.yaml
@@ -10,7 +10,6 @@ data:
     # RHEL 9 unwanted entries:
     # Was in RHEL only because of Google Chrome, not needed anymore as they use dbus api for tray icon
     - libappindicator
-    - libdbusmenu
     - libindicator
     - libayatana-appindicator
     - libayatana-ido


### PR DESCRIPTION
sst_i18n now depends on this for ibus-panel and is planning to ship in CRB.

https://issues.redhat.com/browse/RHEL-36250

/cc @tpopela 