### PR TITLE
Add gnome-shell-extension-no-overview

### DIFF
--- a/configs/sst_i18n-gnome-desktop-testing.yaml
+++ b/configs/sst_i18n-gnome-desktop-testing.yaml
@@ -6,6 +6,7 @@ data:
   maintainer: sst_i18n
   packages:
     - gnome-desktop-testing
+    - gnome-shell-extension-no-overview
   labels:
     - eln
     - c10s


### PR DESCRIPTION
This is intended for IBus CI testing: https://issues.redhat.com/browse/RHEL-54599

/cc @fujiwarat 