### PR TITLE
Add rpmautospec to ELN Extras

### DIFF
--- a/configs/eln_buildroot.yaml
+++ b/configs/eln_buildroot.yaml
@@ -8,4 +8,5 @@ data:
     - rpmautospec
   labels:
     - eln
+    - eln-extras
     - c10s


### PR DESCRIPTION
python-rpmautospec will be buildroot-only in RHEL, and is therefore needed in EPEL to allow packages to be built.

/cc @sgallagher 