### PR TITLE
Exclude acpica-tools on s390x

### DIFF
--- a/configs/sst_arch_hw.yaml
+++ b/configs/sst_arch_hw.yaml
@@ -5,7 +5,6 @@ data:
   description: Packages for hardware enablement
   maintainer: sst_arch_hw
   packages:
-    - acpica-tools
     - bluez
     - alsa-firmware
     - alsa-sof-firmware
@@ -29,7 +28,10 @@ data:
     - s390utils
     - s390utils-se-data
   arch_packages:
+    aarch64:
+      - acpica-tools
     ppc64le:
+      - acpica-tools
       - libnxz
       - libnxz-devel
       - libnxz-static
@@ -64,6 +66,7 @@ data:
       - s390utils-zdsfs
       - s390utils-ziomon
     x86_64:
+      - acpica-tools
       - mcelog
       - tboot
       - pcm


### PR DESCRIPTION
https://src.fedoraproject.org/rpms/acpica-tools/c/bada08a9e12545c2332d6df5f31d31cf81d97606

/cc @ahs3