### PR TITLE
sst_gpu-X11-environment: Add xrdb

### DIFF
--- a/configs/sst_gpu-X11-enviroment.yaml
+++ b/configs/sst_gpu-X11-enviroment.yaml
@@ -7,6 +7,7 @@ data:
   packages:
     - libXaw
     - mesa-libGLU
+    - xrdb
     - xrestop
   labels:
     - eln


### PR DESCRIPTION
It makes sense to ship this while we still have support for X11 clients, and is actively used by other packages that we still ship for configuration of their drawing (Xt, Xaw, etc).

Related: https://issues.redhat.com/browse/GPU-1145