### PR TITLE
Add python3-dnf-plugin-pre-transaction-actions

### DIFF
--- a/configs/sst_cs_software_management-package-manager.yaml
+++ b/configs/sst_cs_software_management-package-manager.yaml
@@ -9,6 +9,7 @@ data:
     - dnf-automatic
     - dnf-plugins-core
     - python3-dnf-plugin-post-transaction-actions
+    - python3-dnf-plugin-pre-transaction-actions
     - python3-dnf-plugin-versionlock
     - rpm
     - rpm-apidocs


### PR DESCRIPTION
A new subpackage of dnf-plugins-core, complement to python3-dnf-plugin-post-transaction-actions, which is already in the workloads.

https://issues.redhat.com/browse/RHEL-38831
https://issues.redhat.com/browse/ENGCMP-4445