### PR TITLE
sst_gpu: Add xhost to X11 server workload

### DIFF
--- a/configs/sst_gpu-X11-server.yaml
+++ b/configs/sst_gpu-X11-server.yaml
@@ -7,6 +7,8 @@ data:
   packages:
     # x11 server
     - xorg-x11-server-Xwayland
+    # needed for e.g. allowing to listen over a TCP socket
+    - xhost
   labels:
     - eln
     - c10s


### PR DESCRIPTION
It's needed for things like listening to a TCP socket.