### PR TITLE
Exclude python3-etcd from ELN

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -91,6 +91,7 @@ data:
         # unwanted python deps
         - python3-build
         - python3-docs
+        - python3-etcd
         - python3-hypothesis
         - python3-ipython
         - python3-pillow

--- a/configs/sst_program-unwanted.yaml
+++ b/configs/sst_program-unwanted.yaml
@@ -22,6 +22,7 @@ data:
     - compat-golang-github-coreos-etcd-devel
     - golang-etcd-devel
     - golang-etcd-etcdserver-api-3rpc-devel
+    - python3-etcd
     - fedora-packager
     - fedora-packager-yubikey
     - fedpkg


### PR DESCRIPTION
This is an unwanted build dependency of Fedora samba builds.