### PR TITLE
Enable RHSM support in RHEL

### DIFF
--- a/configs/sst_cs_software_management-package-manager-dnf5.yaml
+++ b/configs/sst_cs_software_management-package-manager-dnf5.yaml
@@ -7,6 +7,7 @@ data:
   packages:
     - dnf5
     - dnf5-plugins
+    - librhsm
     - rpm
     - rpm-apidocs
     - rpm-cron

--- a/configs/sst_cs_software_management-package-manager.yaml
+++ b/configs/sst_cs_software_management-package-manager.yaml
@@ -8,6 +8,7 @@ data:
     - dnf
     - dnf-automatic
     - dnf-plugins-core
+    - librhsm
     - python3-dnf-plugin-post-transaction-actions
     - python3-dnf-plugin-pre-transaction-actions
     - python3-dnf-plugin-versionlock


### PR DESCRIPTION
libdnf is compiled without RHSM support in CentOS Stream, but with the support in RHEL. This difference is intetional to prevent CentOS Stream systems from accidentally accessing RHEL repositories.

To stop content resolver from reporting "unneeded librhsm", add librhsm to DNF workloads.