### PR TITLE
sst_csi_client_tools: add yara

### DIFF
--- a/configs/sst_csi_client_tools.yaml
+++ b/configs/sst_csi_client_tools.yaml
@@ -14,6 +14,7 @@ data:
     - virt-who
     - yggdrasil
     - yggdrasil-worker-package-manager
+    - yara
   package_placeholders:
     - srpm_name: insights-client
       rpms:


### PR DESCRIPTION
This RHEL-only package exists already in 8 and 9, and it was forgotten from 10