### PR TITLE
Drop ResilientStorage repositories

### DIFF
--- a/configs/repository-c10s.yaml
+++ b/configs/repository-c10s.yaml
@@ -41,15 +41,6 @@ data:
         limit_arches:
           - x86_64
         priority: 2
-      RS:
-        baseurl: https://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/ResilientStorage/$basearch/os/
-        koji_api_url: https://kojihub.stream.centos.org/kojihub
-        koji_files_url: https://kojihub.stream.centos.org/kojifiles
-        limit_arches:
-          - ppc64le
-          - s390x
-          - x86_64
-        priority: 2
       SAP:
         baseurl: https://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/SAP/$basearch/os/
         koji_api_url: https://kojihub.stream.centos.org/kojihub

--- a/configs/repository-fedora-eln-extras.yaml
+++ b/configs/repository-fedora-eln-extras.yaml
@@ -40,12 +40,6 @@ data:
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
         limit_arches: ["x86_64"]
-      RS:
-        baseurl: https://kojipkgs.fedoraproject.org/compose/eln/latest-Fedora-eln/compose/ResilientStorage/$basearch/os/
-        priority: 2
-        koji_api_url: https://koji.fedoraproject.org/kojihub
-        koji_files_url: https://kojipkgs.fedoraproject.org
-        limit_arches: ["ppc64le", "s390x", "x86_64"]
       SAP:
         baseurl: https://kojipkgs.fedoraproject.org/compose/eln/latest-Fedora-eln/compose/SAP/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub

--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -51,12 +51,6 @@ data:
         koji_api_url: https://koji.fedoraproject.org/kojihub
         koji_files_url: https://kojipkgs.fedoraproject.org
         limit_arches: ["x86_64"]
-      RS:
-        baseurl: https://kojipkgs.fedoraproject.org/compose/eln/latest-Fedora-eln/compose/ResilientStorage/$basearch/os/
-        priority: 2
-        koji_api_url: https://koji.fedoraproject.org/kojihub
-        koji_files_url: https://kojipkgs.fedoraproject.org
-        limit_arches: ["ppc64le", "s390x", "x86_64"]
       SAP:
         baseurl: https://kojipkgs.fedoraproject.org/compose/eln/latest-Fedora-eln/compose/SAP/$basearch/os/
         koji_api_url: https://koji.fedoraproject.org/kojihub


### PR DESCRIPTION
This variant has been disabled in c10s:

https://gitlab.com/redhat/centos-stream/release-engineering/pungi-centos/-/merge_requests/825