### PR TITLE
Remove yajl

### DIFF
--- a/configs/sst_container_tools-unwanted.yaml
+++ b/configs/sst_container_tools-unwanted.yaml
@@ -11,6 +11,7 @@ data:
     - python3-podman-api
     - runc
     - slirp4netns
+    - yajl
   labels:
     - eln
     - c10s

--- a/configs/sst_container_tools.yaml
+++ b/configs/sst_container_tools.yaml
@@ -26,7 +26,6 @@ data:
     - skopeo
     - toolbox
     - udica
-    - yajl
   package_placeholders:
     - srpm_name: container-tools
       build_dependencies: []


### PR DESCRIPTION
libvirt has switched to json-c, and crun uses an embedded yajl as of RHEL 10.

https://src.fedoraproject.org/rpms/crun/pull-request/72
https://github.com/containers/crun/pull/1583
https://gitlab.com/redhat/centos-stream/rpms/crun/-/merge_requests/102

/cc @jnovy @cgwalters 