### PR TITLE
Drop obsolete texlive-ms

### DIFF
--- a/configs/sst_cs_base_utils-text-processing.yaml
+++ b/configs/sst_cs_base_utils-text-processing.yaml
@@ -241,7 +241,6 @@ data:
     - texlive-modes
     - texlive-mparhack
     - texlive-mptopdf
-    - texlive-ms
     - texlive-multido
     - texlive-multirow
     - texlive-multitoc


### PR DESCRIPTION
This was replaced with separate count1to and multitoc subpackages in texlive 2024.

/cc @ngothan 