### PR TITLE
KDE: disable apps still based on KF5

### DIFF
--- a/configs/eln_extras_kde.yaml
+++ b/configs/eln_extras_kde.yaml
@@ -6,12 +6,12 @@ data:
   maintainer: tdawson
   packages:
     - alligator
-    - amarok
+    #- amarok
     - analitza
     - ark
     - ark-libs
-    - artikulate
-    - artikulate-libs
+    #- artikulate
+    #- artikulate-libs
     - atlantik
     - audex
     - audiotube
@@ -23,7 +23,7 @@ data:
     - breeze-icon-theme
     - breeze-icon-theme-rcc
     - calindori
-    - cervisia
+    #- cervisia
     - colord-kde
     - dolphin
     - dolphin-libs
@@ -50,7 +50,7 @@ data:
     - kalm
     - kalzium
     - kamera
-    - kamoso
+    #- kamoso
     - kanagram
     - kapman
     - kapptemplate
@@ -70,11 +70,11 @@ data:
     - kcharselect
     - kclock
     - kcolorchooser
-    - kcolorpicker
+    - kcolorpicker-qt6
     - kcron
-    - kdb
-    - kdb-driver-mysql
-    - kdb-driver-postgresql
+    #- kdb
+    #- kdb-driver-mysql
+    #- kdb-driver-postgresql
     - kdebugsettings
     - kde-cli-tools
     - kde-connect
@@ -108,8 +108,8 @@ data:
     - kdnssd
     - keditbookmarks
     - keditbookmarks-libs
-    - kexi
-    - kexi-libs
+    #- kexi
+    #- kexi-libs
     - keysmith
     - kf6-attica
     - kf6-baloo
@@ -192,7 +192,7 @@ data:
     - kgoldrunner
     - kgraphviewer
     - khangman
-    - kig
+    #- kig
     - kigo
     - kile
     - killbots
@@ -213,7 +213,7 @@ data:
     - kmahjongg
     - kmenuedit
     - kmines
-    - kmix
+    #- kmix
     - kmousetool
     - kmouth
     - kmplot
@@ -236,11 +236,11 @@ data:
     - konversation
     - kpartloader
     - kpmcore
-    - kproperty
-    - kqtquickcharts
+    #- kproperty
+    #- kqtquickcharts
     - krdc
     - krdc-libs
-    - kreport
+    #- kreport
     - kreversi
     - krfb
     - krfb-libs
@@ -261,7 +261,7 @@ data:
     - ktimer
     - ktorrent
     - ktorrent-libs
-    - ktouch
+    #- ktouch
     - ktrip
     - ktuberling
     - kturtle
@@ -270,8 +270,8 @@ data:
     - kuserfeedback
     - kuserfeedback-console
     - kwalletmanager5
-    - kwave
-    - kwayland-integration
+    #- kwave
+    #- kwayland-integration
     - kweather
     - kwin
     - kwin-common
@@ -294,19 +294,19 @@ data:
     - lokalize
     - lskat
     - maliit-keyboard
-    - marble
-    - marble-astro
-    - marble-common
-    - marble-qt
-    - marble-widget-data
+    #- marble
+    #- marble-astro
+    #- marble-common
+    #- marble-qt
+    #- marble-widget-data
     - markdownpart
     - marknote
     - massif-visualizer
     - minuet
     - neochat
     - nheko
-    - okteta
-    - okteta-libs
+    #- okteta
+    #- okteta-libs
     - oxygen-icon-theme
     - oxygen-sound-theme
     - palapeli
@@ -367,8 +367,8 @@ data:
     - qt-creator-doc
     - qt-creator-translations
     - qt-settings
-    - rocs
-    - rocs-libs
+    #- rocs
+    #- rocs-libs
     - ruqola
     - sddm
     - sddm-breeze
@@ -381,7 +381,7 @@ data:
     - step
     - svgpart
     - sweeper
-    - umbrello
+    #- umbrello
     - xdg-desktop-portal-kde
     - yakuake
   labels:


### PR DESCRIPTION
EPEL 10 will include parts of Qt5 but not KF5.  Some of these will be ported to KF6 in KDE Gear 24.12, at which point they can be re-enabled.

/cc @tdawson 