### PR TITLE
Add gvisor-tap-vsock

### DIFF
--- a/configs/sst_container_tools.yaml
+++ b/configs/sst_container_tools.yaml
@@ -19,6 +19,7 @@ data:
     - criu
     - crun
     - fuse-overlayfs
+    - gvisor-tap-vsock
     - netavark
     - oci-seccomp-bpf-hook
     - podman


### PR DESCRIPTION
This replaces libslirp in the containers stack as of RHEL 9.

/cc @jnovy @cgwalters