### PR TITLE
Add ELN exclusions

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -80,6 +80,8 @@ data:
         # openjdk-portable packages are built against the oldest supported
         # RHEL version, will not be imported into next RHEL version
         - java-*-openjdk-portable*
+        # doc generation tools with unwanted dependencies
+        - fop
         # pulls in GHC stack
         - pandoc
         # unwanted python deps
@@ -117,7 +119,9 @@ data:
         - xen-libs
         - xen-devel
         # rust lib crates are unwanted; dependencies must be vendored
+        - cargo-c
         - cargo-rpm-macros
+        - cbindgen
         - rust-srpm-macros
         - rust-*-devel
         # ELN has only a subset of texlive; avoid components only in Fedora


### PR DESCRIPTION
cargo-c is sometimes (e.g. librsvg2) used to create shared libraries from Rust code, and cbindgen is used by Mozilla products (mozjs128, firefox, and thunderbird); both are intended to be vendored in RHEL.  Also, expand the list of unwanted documentation tools to include fop.