### PR TITLE
Add workload for libcamera

### DIFF
--- a/configs/sst_display_hardware-libcamera.yaml
+++ b/configs/sst_display_hardware-libcamera.yaml
@@ -1,0 +1,29 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: libcamera
+  description: A library to support complex camera ISPs
+  maintainer: sst_display_hardware_multimedia
+  packages: []
+  arch_packages:
+    aarch64:
+      - libcamera
+      - libcamera-devel
+      - libcamera-tools
+      - libcamera-ipa
+      - libcamera-qcam
+      - libcamera-gstreamer
+      - libcamera-v4l2
+      - pipewire-plugin-libcamera
+    x86_64:
+      - libcamera
+      - libcamera-devel
+      - libcamera-tools
+      - libcamera-ipa
+      - libcamera-qcam
+      - libcamera-gstreamer
+      - libcamera-v4l2
+      - pipewire-plugin-libcamera
+  labels:
+    - eln
+    - c10s


### PR DESCRIPTION
Create a new workload for libcamera which is needed to support MIPI Cameras in RHEL.
Related to https://issues.redhat.com/browse/RHEL-58621.