### PR TITLE
Remove pacemaker-nagios-plugins-metadata

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -82,6 +82,7 @@ data:
         - java-*-openjdk-portable*
         # doc generation tools with unwanted dependencies
         - fop
+        - ImageMagick
         # pulls in GHC stack
         - pandoc
         # unwanted python deps

--- a/configs/sst_csi_client_tools.yaml
+++ b/configs/sst_csi_client_tools.yaml
@@ -26,7 +26,6 @@ data:
             - pciutils
             - policycoreutils-python-utils
             - python3-PyYAML
-            - python3-magic
             - python3-requests
             - python3-setuptools
             - python3-six

--- a/configs/sst_high_availability-userspace.yaml
+++ b/configs/sst_high_availability-userspace.yaml
@@ -292,7 +292,6 @@ data:
       - pacemaker-cts
       - pacemaker-doc
       - pacemaker-libs-devel
-      - pacemaker-nagios-plugins-metadata
       - pacemaker-remote
       - resource-agents
       - sbd
@@ -326,7 +325,6 @@ data:
       - pacemaker-cts
       - pacemaker-doc
       - pacemaker-libs-devel
-      - pacemaker-nagios-plugins-metadata
       - pacemaker-remote
       - resource-agents
       - sbd
@@ -360,7 +358,6 @@ data:
       - pacemaker-cts
       - pacemaker-doc
       - pacemaker-libs-devel
-      - pacemaker-nagios-plugins-metadata
       - pacemaker-remote
       - resource-agents
       - sbd


### PR DESCRIPTION
This was removed upstream in pacemaker 3.0.0~rc1:

https://src.fedoraproject.org/rpms/pacemaker/c/394383f0ffe98652f064be9fc234523cd4dbdac4

/cc @feist @CtrlZmaster 