### PR TITLE
Realign Content Resolver workloads post Dev/QE merger

### DIFF
--- a/configs/sst_display_hardware_multimedia-HID-drivers.yaml
+++ b/configs/sst_display_hardware_multimedia-HID-drivers.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: HID drivers
   description: Contains the user space eBPF drivers for the HID subsystem
-  maintainer: sst_gpu
+  maintainer: sst_display_hardware_multimedia
   packages:
     - udev-hid-bpf
   labels:

--- a/configs/sst_display_hardware_multimedia-audio-playback.yaml
+++ b/configs/sst_display_hardware_multimedia-audio-playback.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Audio playback
   description: Libraries and daemons for audio playback
-  maintainer: sst_gpu
+  maintainer: sst_display_hardware_multimedia
   packages:
     - pipewire-pulseaudio
     - libcanberra

--- a/configs/sst_display_hardware_multimedia-codecs.yaml
+++ b/configs/sst_display_hardware_multimedia-codecs.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Codecs
   description: Various codecs
-  maintainer: sst_gpu
+  maintainer: sst_display_hardware_multimedia
   packages:
     - libtheora
     - sbc

--- a/configs/sst_display_hardware_multimedia-graphics-development-libraries.yaml
+++ b/configs/sst_display_hardware_multimedia-graphics-development-libraries.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Graphics development libraries
   description: Libraries used for development of graphics applications
-  maintainer: sst_gpu
+  maintainer: sst_display_hardware_multimedia
   packages:
     - libdecor
     - SDL

--- a/configs/sst_display_hardware_multimedia-multimedia-libraries.yaml
+++ b/configs/sst_display_hardware_multimedia-multimedia-libraries.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Multimedia libraries
   description: Libraries for managing multimedia content
-  maintainer: sst_gpu
+  maintainer: sst_display_hardware_multimedia
   packages:
     - gstreamer1
     - gstreamer1-plugins-base

--- a/configs/sst_display_hardware_multimedia-multimedia-sharing.yaml
+++ b/configs/sst_display_hardware_multimedia-multimedia-sharing.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Multimedia sharing
   description: For screen sharing and camera access
-  maintainer: sst_gpu
+  maintainer: sst_display_hardware_multimedia
   packages:
     - pipewire
     - wireplumber

--- a/configs/sst_display_hardware_multimedia-unwanted.yaml
+++ b/configs/sst_display_hardware_multimedia-unwanted.yaml
@@ -11,6 +11,23 @@ data:
     - re2c
     # Totem is removed from RHEL 10, avoid usage in other components
     - totem-pl-parser
+    # Replaced by tools in libinput
+    - evemu
+    # BR for rubygem-clutter-gstreamer. Said rubygem shouldn't be in EL9. Also, superseeded by clutter-gst3.
+    - clutter-gst2
+    # Virtually unused even in Fedora, might have been used by spice once upon a time. Also, superseeded by opus.
+    - celt051
+    # Only used for some old games and emulators
+    - SFML
+    # Only used by some multimedia apps we don't ship
+    - libmpcdec
+    # Seems unused
+    - libsamplerate
+    # Only used by openal-soft examples, brings in other unwanted deps
+    - SDL_sound
+    # Removed in favor of pipewire(-pulse). Note that the SRPM with the same
+    # name should still be built for some packages, like pulseaudio-libs
+    - pulseaudio
   labels:
     - eln
     - c10s

--- a/configs/sst_display_window_management-Wayland-Infrastructure.yaml
+++ b/configs/sst_display_window_management-Wayland-Infrastructure.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Wayland infrastructure
   description: Contains tools and related infrastructure used in a Wayland environment
-  maintainer: sst_gpu
+  maintainer: sst_display_window_management
   packages:
     - wayland-utils
     - waypipe

--- a/configs/sst_display_window_management-X11-enviroment.yaml
+++ b/configs/sst_display_window_management-X11-enviroment.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: Traditional X11 environment
   description: Libraries and sample applications historically provided with an X11 installation
-  maintainer: sst_gpu
+  maintainer: sst_display_window_management
   packages:
     - libXaw
     - mesa-libGLU

--- a/configs/sst_display_window_management-X11-server.yaml
+++ b/configs/sst_display_window_management-X11-server.yaml
@@ -3,7 +3,7 @@ version: 1
 data:
   name: X11 Server
   description: Provide the server side for the X window system
-  maintainer: sst_gpu
+  maintainer: sst_display_window_management
   packages:
     # x11 server
     - xorg-x11-server-Xwayland

--- a/configs/sst_display_window_management-unwanted.yaml
+++ b/configs/sst_display_window_management-unwanted.yaml
@@ -1,0 +1,45 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Window Management - Blocked packages
+  description: Window Management - Packages which should not be in ELN
+  maintainer: sst_window_management
+  unwanted_packages:
+    # Seems to only be used by hwloc in an optional plugin
+    - libXNVCtrl
+    # Not very used and the only consumer of xorg-sgml-doctools
+    - xorg-x11-docs
+    # Remove in favor of the modessting drivers for ati, intel and nouveau
+    - xorg-x11-drv-intel
+    - xorg-x11-drv-nouveau
+    - xorg-x11-drv-ati
+    # Remove as its provides quite a bad user experience and we can avoid to maintain vesa
+    - xorg-x11-drv-vesa
+    # Ancient build system, with low upstream maintenance.
+    # Historically used in some older Xorg projects
+    - imake
+    # Only used by optional plugin of hwloc, removed for RHEL.
+    - libXNVCtrl
+    # Deprecated since RHEL 9 (technically even 8.4), removed in RHEL 10
+    - motif
+    # It should go
+    - libxml++
+    # Xorg removal in RHEL 10
+    - xorg-x11-server-common
+    - xorg-x11-server-devel
+    - xorg-x11-server-source
+    - xorg-x11-server-Xorg
+    - xorg-x11-server-Xnest
+    - xorg-x11-server-Xdmx
+    - xorg-x11-server-Xvfb
+    - xorg-x11-server-Xephyr
+    - xorg-x11-drv-dummy
+    - xorg-x11-drv-evdev
+    - xorg-x11-drv-fbdev
+    - xorg-x11-drv-libinput
+    - xorg-x11-drv-modesetting
+    - xorg-x11-drv-vmware
+    - xorg-x11-drv-wacom
+  labels:
+    - eln
+    - c10s

--- a/configs/sst_gpu-unwanted.yaml
+++ b/configs/sst_gpu-unwanted.yaml
@@ -5,64 +5,11 @@ data:
   description: GPU - Packages which should not be in ELN
   maintainer: sst_gpu
   unwanted_packages:
-    # only used by mesa-demos, but that’s likely to change, see https://gitlab.freedesktop.org/mesa/demos/-/merge_requests/23
-    - glew
-    # HFS+ is not supported in RHEL - not currently packaged in RHEL 8, just adding in case dependencies try to pull it in
-    - hfsplus-tools
-    # Seems to only be used by hwloc in an optional plugin
-    - libXNVCtrl
-    # Not very used and the only consumer of xorg-sgml-doctools
-    - xorg-x11-docs
-    # Remove in favor of the modessting drivers for ati, intel and nouveau
-    - xorg-x11-drv-intel
-    - xorg-x11-drv-nouveau
-    - xorg-x11-drv-ati
-    # Remove as its provides quite a bad user experience and we can avoid to maintain vesa
-    - xorg-x11-drv-vesa
-    # Replaced by tools in libinput
-    - evemu
-    # BR for rubygem-clutter-gstreamer. Said rubygem shouldn't be in EL9. Also, superseeded by clutter-gst3.
-    - clutter-gst2
-    # Virtually unused even in Fedora, might have been used by spice once upon a time. Also, superseeded by opus.
-    - celt051
-    # Ancient build system, with low upstream maintenance.
-    - imake
-    # Only used by optional plugin of hwloc, removed for RHEL.
-    - libXNVCtrl
-    # Deprecated since RHEL 9 (technically even 8.4), removed in RHEL 10
-    - motif
-    # Only used for some old games and emulators
-    - SFML
-    # Only used by some multimedia apps we don't ship
-    - libmpcdec
-    # Seems unused
-    - libsamplerate
-    # It should go
-    - libxml++
-    # Only used by openal-soft examples, brings in other unwanted deps
-    - SDL_sound
     # glew is no longer needed by mesa-demos, and the soname churns too much to be
     # useful for a long-life product like RHEL.
     - glew
-    # Xorg removal in RHEL 10
-    - xorg-x11-server-common
-    - xorg-x11-server-devel
-    - xorg-x11-server-source
-    - xorg-x11-server-Xorg
-    - xorg-x11-server-Xnest
-    - xorg-x11-server-Xdmx
-    - xorg-x11-server-Xvfb
-    - xorg-x11-server-Xephyr
-    - xorg-x11-drv-dummy
-    - xorg-x11-drv-evdev
-    - xorg-x11-drv-fbdev
-    - xorg-x11-drv-libinput
-    - xorg-x11-drv-modesetting
-    - xorg-x11-drv-vmware
-    - xorg-x11-drv-wacom
-    # Removed in favor of pipewire(-pulse). Note that the SRPM with the same
-    # name should still be built for some packages, like pulseaudio-libs
-    - pulseaudio
+    # HFS+ is not supported in RHEL - not currently packaged in RHEL 8, just adding in case dependencies try to pull it in
+    - hfsplus-tools
   labels:
     - eln
     - c10s


### PR DESCRIPTION
Some components got shuffled around, so it makes sense that we also align the content workloads with the new org structure.

For the unwanted packages, splitting this up over the multiple SSTs was a bit harder since they contains for example some very historical dependencies of e.g. Xorg or some multimedia libraries. I tried to move those the most appropriate SST where possible.