### PR TITLE
Drop eza from Extras

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -23,7 +23,6 @@ data:
     - duo_unix-selinux
     - ebranch
     - et
-    - eza
     - htop
     - iotools
     - fd-find


### PR DESCRIPTION
rust-eza was retired due to "license shenanigans":

https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/PHL4R4AQPKOR6QTNRFAKHCHIMWRFAW6C/#MDMTSAPU7XOKY2LLZMPIBPBJY2O6AXJ7

/cc @davide125 @michel-slm 