### PR TITLE
Skip rpmdistro-repoquery temporarily

### DIFF
--- a/configs/eln_extras_fedora-packager.yaml
+++ b/configs/eln_extras_fedora-packager.yaml
@@ -15,6 +15,6 @@ data:
     - mock
     - rpm-build
     - rpmdevtools
-    - rpmdistro-repoquery
+#    - rpmdistro-repoquery
   labels:
     - eln-extras

--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -59,7 +59,7 @@ data:
     - python3-pystemd
     - python3-testslide
     - python3-zstd
-    - rpmdistro-repoquery
+#    - rpmdistro-repoquery
     - rpminspect
     - rpminspect-data-centos
     - rpminspect-data-fedora


### PR DESCRIPTION
This requires dnf4 which is no longer available for rawhide and ELN.