### PR TITLE
Fix typos in sst_cs_databases workload descriptions

### DIFF
--- a/configs/sst_cs_databases-db-mariadb.yaml
+++ b/configs/sst_cs_databases-db-mariadb.yaml
@@ -2,7 +2,7 @@ document: feedback-pipeline-workload
 version: 1
 data:
   name: MariaDB client and server
-  description: Client tools and a server daemon for MariaDB, with Galera repliechoion
+  description: Client tools and a server daemon for MariaDB, with Galera replication
   maintainer: sst_cs_databases
   packages:
     - galera

--- a/configs/sst_cs_databases-embedded.yaml
+++ b/configs/sst_cs_databases-embedded.yaml
@@ -2,7 +2,7 @@ document: feedback-pipeline-workload
 version: 1
 data:
   name: Enbedded databases
-  description: Popular key/value databases available for appliechoion development
+  description: Popular key/value databases available for application development
   maintainer: sst_cs_databases
   packages:
     - gdbm-devel


### PR DESCRIPTION
`s/echo/cat/`