### PR TITLE
Drop grammalecte

### DIFF
--- a/configs/eln_extras_libreoffice.yaml
+++ b/configs/eln_extras_libreoffice.yaml
@@ -99,7 +99,6 @@ data:
     - libreoffice-langpack-zu
     # third-party extensions
     - libreoffice-gallery-vrt-network-equipment
-    - libreoffice-grammalecte
     - openoffice.org-diafilter
   labels:
     - eln-extras


### PR DESCRIPTION
The maintainer does not wish to have this package in EPEL:

https://src.fedoraproject.org/rpms/grammalecte/pull-request/2