### PR TITLE
Revert "Skip rpmdistro-repoquery temporarily"

### DIFF
--- a/configs/eln_extras_fedora-packager.yaml
+++ b/configs/eln_extras_fedora-packager.yaml
@@ -15,6 +15,6 @@ data:
     - mock
     - rpm-build
     - rpmdevtools
-#    - rpmdistro-repoquery
+    - rpmdistro-repoquery
   labels:
     - eln-extras

--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -59,7 +59,7 @@ data:
     - python3-pystemd
     - python3-testslide
     - python3-zstd
-#    - rpmdistro-repoquery
+    - rpmdistro-repoquery
     - rpminspect
     - rpminspect-data-centos
     - rpminspect-data-fedora


### PR DESCRIPTION
rpmdistro-repoquery can now use dnf5:

https://pagure.io/rpmdistro-repoquery/c/2dd813432d5c832704077c4555f3d0e459e438c9 https://src.fedoraproject.org/rpms/rpmdistro-repoquery/c/7f8259593cf8c62ff41595209c11eb893ea40066

This reverts commit 3412737297dd9489449104422b23d7ceed1e81b0.