### PR TITLE
Skip fedora-easy-karma temporarily

### DIFF
--- a/configs/eln_extras_fedora-packager.yaml
+++ b/configs/eln_extras_fedora-packager.yaml
@@ -6,7 +6,7 @@ data:
   maintainer: epel-sig
   packages:
     - bodhi-client
-    - fedora-easy-karma
+#    - fedora-easy-karma
     - fedora-packager
     - fedora-repoquery
     - fedpkg


### PR DESCRIPTION
This depends on python-fedora which was recently retired for lack of a maintainer.