### PR TITLE
Move copy-jdk-configs to unwanted

### DIFF
--- a/configs/sst_java-java.yaml
+++ b/configs/sst_java-java.yaml
@@ -17,7 +17,6 @@ data:
     - java-21-openjdk-jmods
     - java-21-openjdk-src
     - java-21-openjdk-static-libs
-    - copy-jdk-configs
     # Debug packages should be built but shipped in CRB
     - java-21-openjdk-slowdebug
     - java-21-openjdk-demo-slowdebug

--- a/configs/sst_java-unwanted.yaml
+++ b/configs/sst_java-unwanted.yaml
@@ -84,3 +84,5 @@ data:
     - java-11-openjdk-portable
     - java-17-openjdk-portable
     - java-21-openjdk-portable
+    # Parallel installations of the same JDK are no longer supported in RHEL 10 and so no dependency on copy-jdk-configs
+    - copy-jdk-configs


### PR DESCRIPTION
Parallel installations of the same JDK are no longer supported and the dependency on copy-jdk-configs has been dropped.

Resolves: RHELMISC-7203