### PR TITLE
Update rust components

### DIFF
--- a/configs/sst_pt_llvm_rust_go-rust-toolset.yaml
+++ b/configs/sst_pt_llvm_rust_go-rust-toolset.yaml
@@ -14,11 +14,15 @@ data:
     - rust-lldb
     - rust-std-static
     - rust-std-static-wasm32-unknown-unknown
-    - rust-std-static-wasm32-wasi
     - rust-std-static-wasm32-wasip1
     - rustfmt
     - rust-toolset-srpm-macros
     - rust-toolset
+  arch_packages:
+    aarch64:
+      - rust-std-static-aarch64-unknown-none-softfloat
+    x86_64:
+      - rust-std-static-x86_64-unknown-none
   labels:
     - eln
     - c10s


### PR DESCRIPTION
Unversioned wasm32-wasi deprecation:
https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html

Re-enable aarch64-unknown-none-softfloat target:
https://src.fedoraproject.org/rpms/rust/c/f737b8c4dddc2d64481479aec6c85bead138c1af

/cc @cuviper 