### PR TITLE
configs/sst_image_builder: add cockpit-image-builder package

### DIFF
--- a/configs/sst_image_builder-composer.yaml
+++ b/configs/sst_image_builder-composer.yaml
@@ -8,4 +8,4 @@ data:
     - eln
     - c10s
   packages:
-    - cockpit-composer
+    - cockpit-image-builder


### PR DESCRIPTION
The cockpit-image-builder-package will replace cockpit-composer.

Resolves: RHELPLAN-171387