### PR TITLE
eln_extras_meta: Move azure-cli to separate workload

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -6,7 +6,6 @@ data:
   maintainer: meta-sig
   packages:
     - atop
-    - azure-cli
     - b4
     - below
     - btrd

--- a/configs/eln_extras_meta_cloud.yaml
+++ b/configs/eln_extras_meta_cloud.yaml
@@ -1,0 +1,10 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: meta-sig cloud packages
+  description: Packages needed by Cloud teams
+  maintainer: meta-sig
+  packages:
+    - azure-cli
+  labels:
+    - eln-extras


### PR DESCRIPTION
This minimizes the blast radius when it fails to build