### PR TITLE
Drop ncdu from Extras

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -41,7 +41,6 @@ data:
     - mlnx-tools
     - mkosi
     - mosh
-    - ncdu
     - ncurses-compat-libs
     - neovim
     - netconsd


### PR DESCRIPTION
ncdu 2.x is a complete rewrite in Zig.  The Zig compiler currently requires an LLVM with all default targets enabled, which RHEL's llvm does not. Therefore, the only ways to build zig for EPEL would be for a compat llvm version to be built for EPEL with all targets enabled (and limit zig to llvm versions which are not the default version in RHEL, which is continuously rebased), or for zig to be patched to not support all arches.

Neither possibility seems likely, and as ncdu is more of a "nice to have" it's probably best to simply expect it won't be possible for EPEL 11.

/cc @davide125 @michel-slm 