### PR TITLE
Exclude jack-audio-connection-kit

### DIFF
--- a/configs/repository-fedora-eln-extras.yaml
+++ b/configs/repository-fedora-eln-extras.yaml
@@ -69,6 +69,8 @@ data:
         # openjdk-portable packages are built against the oldest supported
         # RHEL version, will not be imported into next RHEL version
         - java-*-openjdk-portable*
+        # prefer pipewire-jack
+        - jack-audio-connection-kit
         # prefer grubby
         - sdubby
         priority: 4

--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -80,6 +80,8 @@ data:
         # openjdk-portable packages are built against the oldest supported
         # RHEL version, will not be imported into next RHEL version
         - java-*-openjdk-portable*
+        # prefer pipewire-jack
+        - jack-audio-connection-kit
         # doc generation tools with unwanted dependencies
         - fop
         - ImageMagick


### PR DESCRIPTION
pipewire-jack should be used instead for RHEL 10+.

https://bugzilla.redhat.com/show_bug.cgi?id=2313997