### PR TITLE
Exclude ocaml-ounit from ELN

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -87,6 +87,8 @@ data:
         - ImageMagick
         # pulls in GHC stack
         - pandoc
+        # unwanted ocaml deps
+        - ocaml-ounit*
         # unwanted python deps
         - python3-build
         - python3-coverage


### PR DESCRIPTION
This is a build dependency of the Fedora build of libguestfs, which occasionally gets pulled into the ELN buildroot when things are broken.