### PR TITLE
Fix unwantedness of pulseaudio

### DIFF
--- a/configs/sst_display_hardware_multimedia-unwanted.yaml
+++ b/configs/sst_display_hardware_multimedia-unwanted.yaml
@@ -25,9 +25,17 @@ data:
     - libsamplerate
     # Only used by openal-soft examples, brings in other unwanted deps
     - SDL_sound
+  unwanted_packages:
     # Removed in favor of pipewire(-pulse). Note that the SRPM with the same
     # name should still be built for some packages, like pulseaudio-libs
     - pulseaudio
+    - pulseaudio-module-bluetooth
+    - pulseaudio-module-gsettings
+    - pulseaudio-module-jack
+    - pulseaudio-module-lirc
+    - pulseaudio-module-x11
+    - pulseaudio-module-zerconf
+    - pulseaudio-qpaeq
   labels:
     - eln
     - c10s


### PR DESCRIPTION
As noted in the comment, the pulseaudio SRPM is not completely unwanted; the various libs subpackages are still needed, while the server and modules are not, and in fact are no longer built for RHEL.

/cc @nielsdg 