### PR TITLE
Revert "Update for tracker->tinysparql and tracker-miners->localsearch"

### DIFF
--- a/configs/sst_display_desktop_foundation-gnome-desktop.yaml
+++ b/configs/sst_display_desktop_foundation-gnome-desktop.yaml
@@ -19,9 +19,9 @@ data:
     - libgweather
     - libproxy
     - libsoup3
-    - localsearch
     - tecla
-    - tinysparql
+    - tracker
+    - tracker-miners
     - xdg-user-dirs-gtk
     - zenity
   labels:

--- a/configs/sst_display_desktop_foundation-unwanted.yaml
+++ b/configs/sst_display_desktop_foundation-unwanted.yaml
@@ -70,9 +70,6 @@ data:
     # tracker3 renamed to tracker in F34+
     - tracker3
     - tracker3-miners
-    # ...and tracker renamed to tinysparql and miners to localsearch in F43+
-    - tracker
-    - tracker-miners
     # libhandy1 renamed to libhandy in F34+
     - libhandy1
     # only GTK 3 and GTK 4 supported in ELN and RHEL 10


### PR DESCRIPTION
This was correct for ELN but not for C10S.  Now that tinysparql/localsearch has been built for ELN, they will still be used as they provide the old tracker names.

Reverts minimization/content-resolver-input#1369

/cc @AdamWill @tpopela 