### PR TITLE
Drop plasma-applet-translator

### DIFF
--- a/configs/eln_extras_kde.yaml
+++ b/configs/eln_extras_kde.yaml
@@ -315,7 +315,6 @@ data:
     - phonon-qt6-backend-vlc
     - php-kolabformat
     - picmi
-    - plasma-applet-translator
     - plasma-breeze
     - plasma-breeze-common
     - plasma-browser-integration


### PR DESCRIPTION
This is a Plasma 5 QML applet which cannot be compatible with Plasma 6 and has not had an upstream release in years.

This should probably be retired from Fedora and EPEL 10 (!) as well.

/cc @tdawson 