### PR TITLE
meta: split off hardware related packages

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -37,9 +37,7 @@ data:
     - libidn-devel
     - libkdumpfile-devel
     - libxcrypt-compat
-    - linux-sysinfo-snapshot
     - mkosi
-    - mlnx-tools
     - mosh
     - ncurses-compat-libs
     - neovim
@@ -82,7 +80,6 @@ data:
       - sedutil
       - sysbench
     x86_64:
-      - msr-tools
       - sedutil
       - sysbench
   labels:

--- a/configs/eln_extras_meta_hw.yaml
+++ b/configs/eln_extras_meta_hw.yaml
@@ -1,0 +1,16 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: meta-sig hardware packages
+  description: ELN Extras packages for hardware support and diagnostics
+  maintainer: meta-sig
+  packages:
+    - aer-inject
+    - linux-sysinfo-snapshot
+    - mce-inject
+    - mlnx-tools
+  arch_packages:
+    x86_64:
+      - msr-tools
+  labels:
+    - eln-extras


### PR DESCRIPTION
Move these from the main workload to a `meta_hw` one

Also start tracking `aer-inject` and `mce-inject`