### PR TITLE
Cleanup obsolete firmware package names

### DIFF
--- a/configs/sst_kernel_maintainers-kernel-unwanted.yaml
+++ b/configs/sst_kernel_maintainers-kernel-unwanted.yaml
@@ -5,9 +5,6 @@ data:
   description: Packages that kernel maintainers sst doesn't want to distribute in RHEL 9
   maintainer: sst_kernel_maintainers
   unwanted_packages:
-    - iwl3945-firmware
-    - iwl4965-firmware
-    - iwl6000-firmware
     - kernel-64k-debug-modules-internal
     - kernel-64k-debug-modules-partner
     - kernel-64k-modules-internal
@@ -20,9 +17,6 @@ data:
     - kernel-selftests-internal
     - kernel-zfcpdump-modules-internal
     - kernel-zfcpdump-modules-partner
-    - libertas-sd8686-firmware
-    - libertas-usb8388-firmware
-    - libertas-usb8388-olpc-firmware
     - liquidio-firmware
   labels:
     - eln

--- a/configs/sst_program-lorax-template.yaml
+++ b/configs/sst_program-lorax-template.yaml
@@ -98,19 +98,8 @@ data:
       - grub2-tools-extra
       - dmidecode
       - linux-firmware
-      - iwl100-firmware
-      - iwl1000-firmware
-      - iwl105-firmware
-      - iwl135-firmware
-      - iwl2000-firmware
-      - iwl2030-firmware
-      - iwl3160-firmware
-      - iwl5000-firmware
-      - iwl5150-firmware
-      - iwl6000g2a-firmware
-      - iwl6000g2b-firmware
-      - iwl6050-firmware
-      - iwl7260-firmware
+      - iwlwifi-dvm-firmware
+      - iwlwifi-mvm-firmware
       - libibverbs
       - rdma-core
     ppc64le:


### PR DESCRIPTION
Handling for the old (per-chip) firmware package names was recently removed from rawhide, and is unneeded for c10s.

https://src.fedoraproject.org/rpms/linux-firmware/c/25343c359bc51d30b1792a80b5d4c29e29c7ac14

/cc @bstinsonmhk 