### PR TITLE
Add CLA selinux subpackage

### DIFF
--- a/configs/sst_rhel_lightspeed.yaml
+++ b/configs/sst_rhel_lightspeed.yaml
@@ -19,11 +19,6 @@ data:
             - python3-requests
             - python3-sqlalchemy
             - systemd
-    - srpm_name: command-line-assistant-selinux
-      limit_arches:
-        - aarch64
-        - x86_64
-      rpms:
         - rpm_name: command-line-assistant-selinux
           description: Command Line Assistant SELinux Policy
           dependencies:

--- a/configs/sst_rhel_lightspeed.yaml
+++ b/configs/sst_rhel_lightspeed.yaml
@@ -20,7 +20,7 @@ data:
             - python3-sqlalchemy
             - systemd
         - rpm_name: command-line-assistant-selinux
-          description: Command Line Assistant SELinux Policy
+          description: Command Line Assistant Selinux Policy
           dependencies:
             - selinux-policy-targeted
   labels:

--- a/configs/sst_rhel_lightspeed.yaml
+++ b/configs/sst_rhel_lightspeed.yaml
@@ -15,7 +15,19 @@ data:
           description: Command Line Assistant
           dependencies:
             - python3
-
+            - python3-dasbus
+            - python3-requests
+            - python3-sqlalchemy
+            - systemd
+    - srpm_name: command-line-assistant-selinux
+      limit_arches:
+        - aarch64
+        - x86_64
+      rpms:
+        - rpm_name: command-line-assistant-selinux
+          description: Command Line Assistant SELinux Policy
+          dependencies:
+            - selinux-policy-targeted
   labels:
     - eln
     - c10s


### PR DESCRIPTION
RHEL Lightspeed team got a new subpackge for selinux policy. This patch updates the yaml file for the sst_rhel_lightspeed to include this new subpackage. 