### PR TITLE
Update pcs dependencies to match the current state

### DIFF
--- a/configs/sst_high_availability-userspace.yaml
+++ b/configs/sst_high_availability-userspace.yaml
@@ -168,8 +168,8 @@ data:
         - automake
         - booth
         - coreutils
+        - corosync-devel
         - corosync-qdevice-devel
-        - corosynclib-devel
         - diffstat
         - findutils
         - gcc
@@ -177,13 +177,13 @@ data:
         - git-core
         - libappstream-glib
         - libcurl-devel
+        - libffi-devel
         - make
         - nodejs-npm
         - nss-tools
         - openssl-devel
         - pacemaker-libs-devel
         - pam
-        - python3
         - pkgconfig
         - python3-cryptography
         - python3-dateutil
@@ -214,12 +214,15 @@ data:
           dependencies:
             - corosync
             - libcurl
+            - libffi
             - libknet1-plugins-all
             - logrotate
             - nss-tools
+            - openssl-libs
             - pacemaker-cli
             - pam
             - pcmk-cluster-manager
+            - pkgconfig
             - psmisc
             - python3
             - python3-cryptography

--- a/configs/sst_high_availability-userspace.yaml
+++ b/configs/sst_high_availability-userspace.yaml
@@ -171,6 +171,7 @@ data:
         - corosync-qdevice-devel
         - corosynclib-devel
         - diffstat
+        - findutils
         - gcc
         - gcc-c++
         - git-core
@@ -183,6 +184,7 @@ data:
         - pacemaker-libs-devel
         - pam
         - python3
+        - pkgconfig
         - python3-cryptography
         - python3-dateutil
         - python3-devel
@@ -190,16 +192,18 @@ data:
         - python3-pip
         - python3-pyparsing
         - python3-setuptools
+        - python3-tornado
         - python3-wheel
         - ruby
         - ruby-devel
-        - rubygems
         - rubygem-bundler
         - rubygem-json
         - rubygem-rexml
         - rubygem-test-unit
+        - rubygems
         - sbd
-        - systemd
+        - systemd-rpm-macros
+        - tar
       limit_arches:
         - x86_64
         - ppc64le
@@ -222,7 +226,7 @@ data:
             - python3-dateutil
             - python3-lxml
             - python3-pyparsing
-            - python3-setuptools
+            - python3-tornado
             - ruby
             - rubygem-json
             - rubygem-rexml


### PR DESCRIPTION
- we unbundled Tornado in RHEL 9.6&10.0GA+
- findutils and tar were used before, just not declared
- systemd-rpm-macros is now used instead of systemd per Fedora Packaging Guidelines example for systemd scriptlet macros

@yselkowitz I have a question about what actually goes in this file... Is it just the BuildRequires declared in the spec file? Or the output of `rpm -q --requires <rpm>` (for Requires) and `rpm -q --requires <srpm>` (for BuildRequires)? There is a difference since the latter also contains dependencies automatically generated by RPM.

And what about `BuildRequires: pkgconfig(booth)`? I changed to this style of dependency to indicate that we only need the pkgconfig of the package and to make sure if the pc file is ever split from the main package, we won't have to make changes. Does it belong here as a resolved rpm name or should I stick to exact copy from the spec file?

I have moved away from declaring [Build]Require `python3` version explicitly in the spec file since rpm generates the correct dependency automatically and Python packages should just BuildRequire `python-devel`. However, I left `python3` in the workload file because it feels wrong removing it.