### PR TITLE
Drop geolite2 databases from ELN

### DIFF
--- a/configs/sst_cs_net_perf_services-geoip-c10s.yaml
+++ b/configs/sst_cs_net_perf_services-geoip-c10s.yaml
@@ -1,11 +1,11 @@
 document: feedback-pipeline-workload
 version: 1
 data:
-  name: GeoIP
-  description: GeoIP tools and libraries
+  name: GeoLite2
+  description: GeoIP databases
   maintainer: sst_cs_net_perf_services
   packages:
-    - libmaxminddb
+    - geolite2-city
+    - geolite2-country
   labels:
-    - eln
     - c10s


### PR DESCRIPTION
These free versions are not planned to be provided in RHEL 11; users will need to get the databases themselves (often commercially).  libmaxminddb remains as a bind dependency for that purpose.