### PR TITLE
Add buildroot strategy to eln-extras view

### DIFF
--- a/configs/view-eln-extras.yaml
+++ b/configs/view-eln-extras.yaml
@@ -9,6 +9,7 @@ data:
   - eln-extras
   base_view_id: view-eln
   repository: repository-fedora-eln-extras
+  buildroot_strategy: root_logs
 
   # Packages to be flagged as unwanted  on specific architectures
   #unwanted_arch_packages:


### PR DESCRIPTION
This is required for eln-extras to view buildroot packages.
This can, and should, be merged before the patch goes into content-resolver.
It will just be ignored if the patch isn't in content-resolver.
