### PR TITLE
Add tdx-qgs package to sst_virtualization

### DIFF
--- a/configs/sst_virtualization-all.yaml
+++ b/configs/sst_virtualization-all.yaml
@@ -28,6 +28,7 @@ data:
       - snphost
       - spice-protocol
       - spice-vdagent
+      - tdx-qgs
       - trustee-guest-components
     ppc64le:
       - powerpc-utils


### PR DESCRIPTION
This is the leaf package for TDX confidential VMs that will pull in all the other dependent SGX related packages.

The TDX feature is limited to Intel x86_64 hardware.