### PR TITLE
Rename network-fastdatapath to network-fastdatapath-ovsdpdk

### DIFF
--- a/configs/sst_network_fastdatapath-fast-packet-processing.yaml
+++ b/configs/sst_network_fastdatapath-fast-packet-processing.yaml
@@ -5,7 +5,7 @@ data:
   description: >
     A set of libraries, drivers and tools required for configuration and fast packet processing.
 
-  maintainer: sst_network_fastdatapath
+  maintainer: sst_network_fastdatapath_ovsdpdk
   packages: []
   arch_packages:
     aarch64:

--- a/configs/sst_network_fastdatapath-openvswitch-exclusion.yaml
+++ b/configs/sst_network_fastdatapath-openvswitch-exclusion.yaml
@@ -5,7 +5,7 @@ data:
   description: >
     The OVS packages are shipped through Fast Datapath repositories and should not be included in Red Hat Enterprise Linux.
 
-  maintainer: sst_network_fastdatapath
+  maintainer: sst_network_fastdatapath_ovsdpdk
   unwanted_packages:
     - openvswitch
     - openvswitch-devel

--- a/configs/sst_network_fastdatapath-tools-lldp.yaml
+++ b/configs/sst_network_fastdatapath-tools-lldp.yaml
@@ -5,7 +5,7 @@ data:
   description: >
     Packages related to network configuration and troubleshooting.
 
-  maintainer: sst_network_fastdatapath
+  maintainer: sst_network_fastdatapath_ovsdpdk
   packages:
     # LLDP support
     - lldpad


### PR DESCRIPTION
Rename network-fastdatapath to network-fastdatapath-ovsdpdk as part of the splitting of the network fastdatapath SST.