### PR TITLE
Add missing sub-packages for gnome-kiosk

### DIFF
--- a/configs/sst_display_window_management-gnome-kiosk.yaml
+++ b/configs/sst_display_window_management-gnome-kiosk.yaml
@@ -6,6 +6,8 @@ data:
   maintainer: sst_display_window_management
   packages:
     - gnome-kiosk
+    - gnome-kiosk-script-session
+    - gnome-kiosk-search-appliance
   labels:
     - eln
     - c10s


### PR DESCRIPTION
gnome-kiosk-script-session and gnome-kiosk-search-appliance are shipped in AppStream and therefore should be part of the workload.

Also required for https://github.com/fedora-eln/eln/issues/228.