### PR TITLE
Add vhost-device-gpu to eln_extras_automotive

### DIFF
--- a/configs/eln_extras_automotive.yaml
+++ b/configs/eln_extras_automotive.yaml
@@ -1,3 +1,4 @@
+---
 document: feedback-pipeline-workload
 version: 1
 data:
@@ -9,11 +10,13 @@ data:
     - qm
   arch_packages:
     x86_64:
+      - vhost-device-gpu
       - vhost-device-scmi
       - vhost-device-sound
       - vhost-device-vsock
       - virglrenderer
     aarch64:
+      - vhost-device-gpu
       - vhost-device-scmi
       - vhost-device-sound
       - vhost-device-vsock


### PR DESCRIPTION
This is the leaf package for `vhost-device-gpu` support which will pull in all needed dependencies
(`virglrenderer` is already in the list):

- `aemu`
- `gfxstream`