### PR TITLE
sst-cockpit: Drop cockpit-ostree

### DIFF
--- a/configs/rhel-sst-cockpit--web-console-c10s.yaml
+++ b/configs/rhel-sst-cockpit--web-console-c10s.yaml
@@ -5,7 +5,7 @@ data:
   description: Cockpit basic packages
   maintainer: rhel-sst-cockpit
   labels:
-    - eln
+    - c10s
   packages:
     # meta-package for the basic stuff (web server, bridge, core pages)
     - cockpit
@@ -13,6 +13,8 @@ data:
     - cockpit-packagekit
     - cockpit-storaged
     - cockpit-doc
+    # RHEL 4 Edge image management
+    - cockpit-ostree
     # extensions maintained by Cockpit team
     - cockpit-files
   arch_packages:


### PR DESCRIPTION
RHEL 4 Edge was only a RHEL 9 thing, and does not exist in RHEL 10 any more. This extension is undermaintained, seems to have no significant user base, and does not make much sense with bootc images. So drop it for RHEL 11.