### PR TITLE
Block dogtak-pki logging dependencies

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -138,6 +138,12 @@ data:
         - texlive-xindy
         # unwanted toolchain
         - mold
+        # dogtag-pki build deps which are vendored in RHEL
+        - fasterxml-oss-parent
+        - jackson-*
+        - jboss-jaxrs-2.0-api
+        - jboss-logging*
+        - pki-resteasy-*
         priority: 4
       Rawhide:
         baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/$basearch/os/


### PR DESCRIPTION
The first step of bundling, which copies these dependencies from the buildroot into the package, has already landed in Fedora.  The second step, which is bundling them in the sources so as not to need standalone versions even in the buildroot, has only landed in RHEL 10 so far; RHEL 11 will certainly do the same, either in Fedora or ELN prior to branching, or in RHEL during branching.
