### PR TITLE
insights-client should not runtime-require python3-setuptools

### DIFF
--- a/configs/rhel-sst-csi-client-tools--all.yaml
+++ b/configs/rhel-sst-csi-client-tools--all.yaml
@@ -26,7 +26,6 @@ data:
             - policycoreutils-python-utils
             - python3-pyyaml
             - python3-requests
-            - python3-setuptools
             - python3-six
             - systemd
             - tar


### PR DESCRIPTION
See https://github.com/RedHatInsights/insights-client/pull/397