### PR TITLE
meta-sig: sequoia-keyring-linter was retired

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -66,7 +66,6 @@ data:
     - rpmrebuild
     - screen
     - sdparm
-    - sequoia-keyring-linter
     - stress
     - stressapptest
     - strongswan


### PR DESCRIPTION
The replacement is `sq cert lint`:

https://src.fedoraproject.org/rpms/rust-sequoia-keyring-linter/c/94784a2dbe293ceefba3d1cd24150f96d7a734cf

/cc @davide125 @michel-slm 