### PR TITLE
Meta: drop atop, add colorized-logs

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -5,12 +5,12 @@ data:
   description: ELN Extras packages that Meta cares about
   maintainer: meta-sig
   packages:
-    - atop
     - b4
     - below
     - btrd
     - ccache
     - colm
+    - colorized-logs
     - ctags
     - dbench
     - debian-keyring


### PR DESCRIPTION
We use below instead of atop

Also track colorized-logs, useful for dealing with output of tools that do not intelligently strip ANSI formatting when piped to other tools