### PR TITLE
Remove oqsprovider from ELN

### DIFF
--- a/configs/rhel-sst-security-crypto--pqc.yaml
+++ b/configs/rhel-sst-security-crypto--pqc.yaml
@@ -9,5 +9,4 @@ data:
     - liboqs
     - oqsprovider
   labels:
-    - eln
     - c10s


### PR DESCRIPTION
openssl 3.5 includes native support for post-quantum crypto algorithms.

/cc @neverpanic 