### PR TITLE
Move python3-setuptools to Python CRB workload

### DIFF
--- a/configs/rhel-sst-pt-python-ruby-nodejs--python-crb-c10s.yaml
+++ b/configs/rhel-sst-pt-python-ruby-nodejs--python-crb-c10s.yaml
@@ -14,6 +14,7 @@ data:
     - python-srpm-macros
     - python-rpm-macros
     - pyproject-rpm-macros
+    - python3-setuptools
     - python3-flit-core
     - python3-cython
     - python3-sphinx

--- a/configs/rhel-sst-pt-python-ruby-nodejs--python-crb-eln.yaml
+++ b/configs/rhel-sst-pt-python-ruby-nodejs--python-crb-eln.yaml
@@ -14,6 +14,7 @@ data:
     - python-srpm-macros
     - python-rpm-macros
     - pyproject-rpm-macros
+    - python3-setuptools
     - python3-flit-core
     - python3-cython
     - python3-sphinx

--- a/configs/rhel-sst-pt-python-ruby-nodejs--python.yaml
+++ b/configs/rhel-sst-pt-python-ruby-nodejs--python.yaml
@@ -8,7 +8,6 @@ data:
     - python3
     - python3-libs
     - python3-pip
-    - python3-setuptools
     - python3-tkinter
     - python-unversioned-command
   labels:


### PR DESCRIPTION
This does not make any difference,
but indicates for our team where we want it to land.

This is meant for RHEL 11+, however since it has no real effect, I made the change for c10s+eln both (as it is easier).