### PR TITLE
rhel-sst-virtualization-cloud--cloud_azure: add azure-vm-utils

### DIFF
--- a/configs/rhel-sst-virtualization-cloud--cloud_azure.yaml
+++ b/configs/rhel-sst-virtualization-cloud--cloud_azure.yaml
@@ -12,3 +12,8 @@ data:
   labels:
     - eln
     - c10s
+  arch_packages:    
+    x86_64:
+      - azure-vm-utils
+    aarch64:
+      - azure-vm-utils


### PR DESCRIPTION
Azure in general only supports 2 arches (x86_64, aarch64) currently, so after discussion in team, we only add the supported 2 arches (x86_64, aarch64) currently. 