### PR TITLE
Block python3-scikit-build-core from ELN

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -110,6 +110,7 @@ data:
         - python3-pytest-randomly
         - python3-pytest-xdist
         - python3-recommonmark
+        - python3-scikit-build-core
         - python3-tox-current-env
         - tox
         # prefer grubby


### PR DESCRIPTION
ibus-typing-booster recently gained an (optional?) dependency on python-rapidfuzz, which BuildRequires: python3-scikit-build-core which pulls in ~200 unwanted dependencies.