### PR TITLE
[extras] add a config management workload for Meta

### DIFF
--- a/configs/eln_extras_meta_config_mgmt.yaml
+++ b/configs/eln_extras_meta_config_mgmt.yaml
@@ -1,0 +1,10 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: meta-sig configuration management packages
+  description: ELN Extras packages for configuration management
+  maintainer: meta-sig
+  packages:
+    - dummy-package-canary
+  labels:
+    - eln-extras


### PR DESCRIPTION
Start by tracking dummy-package-canary which we use to verify that DNF is healthy