### PR TITLE
Drop python-wheel-wheel from Python CRB workload

### DIFF
--- a/configs/rhel-sst-pt-python-ruby-nodejs--python-crb-eln.yaml
+++ b/configs/rhel-sst-pt-python-ruby-nodejs--python-crb-eln.yaml
@@ -19,8 +19,6 @@ data:
     - python3-cython
     - python3-sphinx
     - python3-wheel
-    # note: the following package is called python3-wheel-wheel in RHEL proper:
-    - python-wheel-wheel
     - python3-pytest
     - python3-psutil-tests
     - py3c-devel


### PR DESCRIPTION
It is no longer needed for python and virtualenv and it will no longer be built.

See https://src.fedoraproject.org/rpms/python-wheel/pull-request/40
See https://pagure.io/pungi-fedora/pull-request/1487
See https://pagure.io/fedora-comps/pull-request/1117