### PR TITLE
hyperscale: drop fsverity-utils

### DIFF
--- a/configs/eln_extras_hyperscale.yaml
+++ b/configs/eln_extras_hyperscale.yaml
@@ -9,7 +9,6 @@ data:
     - btrfs-progs
     - centos-packager
     - compsize
-    - fsverity-utils
     - ebtables-legacy
     - ebtables-services
     - iptables-legacy


### PR DESCRIPTION
This has yet to be ported away from OpenSSL ENGINE and has not been built in EPEL 10 or CBS as a result.

/cc @michel-slm per discussion in ELN SIG today.