### PR TITLE
Stop skipping cbindgen

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -134,7 +134,6 @@ data:
         # rust lib crates are unwanted; dependencies must be vendored
         - cargo-c
         - cargo-rpm-macros
-        - cbindgen
         - rust-srpm-macros
         - rust-*-devel
         # ELN has only a subset of texlive; avoid components only in Fedora


### PR DESCRIPTION
cbindgen is already a build dependency of mozjsNNN (usually bundled in RHEL gjs post-branching), and could also be unbundled from firefox and thunderbird. Its CLI only will soon be added to RHEL 9+ as a build dependency of a new package, so it needs to be unblocked, while its -devel packages are still needed in EPEL for building a few other packages.  For now it will be built Fedora-style (with its rust-*-devel dependencies blocked), but how to handle it long-term in ELN still needs to be decided.

https://github.com/fedora-eln/eln/issues/253