### PR TITLE
Disable audiotube temporarily

### DIFF
--- a/configs/eln_extras_kde.yaml
+++ b/configs/eln_extras_kde.yaml
@@ -12,7 +12,7 @@ data:
     #- artikulate
     - atlantik
     - audex
-    - audiotube
+    #- audiotube
     - baloo-widgets
     - blinken
     - bomber


### PR DESCRIPTION
It has a hard dependency on yt-dlp which has yet to be rebuilt for Python 3.14.

/cc @tdawson
