### PR TITLE
Mark gcc14 unwanted

### DIFF
--- a/configs/rhel-sst-pt-gcc--unwanted.yaml
+++ b/configs/rhel-sst-pt-gcc--unwanted.yaml
@@ -53,3 +53,8 @@ data:
     - libbsd
     # Only supported linkers are ld.bfd (binutils) or lld
     - mold
+    # Only the default GCC is supported in ELN, and newer versions in CS
+    # as part of gcc-toolset-NN
+    - gcc14
+    - gcc14-c++
+    - gcc14-gfortran


### PR DESCRIPTION
While being used "temporarily" to unblock the Python 3.14 rebuild of protobuf, this certainly does not belong in the next RHEL.

https://src.fedoraproject.org/rpms/protobuf/pull-request/30