### PR TITLE
Revert "Disable audiotube temporarily"

### DIFF
--- a/configs/eln_extras_kde.yaml
+++ b/configs/eln_extras_kde.yaml
@@ -12,7 +12,7 @@ data:
     #- artikulate
     - atlantik
     - audex
-    #- audiotube
+    - audiotube
     - baloo-widgets
     - blinken
     - bomber


### PR DESCRIPTION
audiotube and yt-dlp have now been rebuilt for Python 3.14.

This reverts commit fef8ee3750657232d5da22710c3d4cf7cf8e9c40.

/cc @tdawson
