### PR TITLE
meta: temporarily delist python3-testslide

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -54,7 +54,7 @@ data:
     - pore
     - pv
     - python3-pystemd
-    - python3-testslide
+#    - python3-testslide
     - python3-zstd
     - qrencode-devel
     - ragel


### PR DESCRIPTION
This has yet to be rebuilt for Python 3.14, and is holding back the rest of this config from Extras.

/cc @michel-slm 