### PR TITLE
Add insights-core-selinux to insights-client dependencies

### DIFF
--- a/configs/rhel-sst-csi-client-tools--all.yaml
+++ b/configs/rhel-sst-csi-client-tools--all.yaml
@@ -53,6 +53,13 @@ data:
           dependencies:
             - subscription-manager
             - systemd
+    - srpm_name: insights-core-selinux
+      rpms:
+        - rpm_name: insights-core-selinux
+          description: insights-core-selinux
+          dependencies:
+            - selinux-policy
+            - selinux-policy-targeted
   labels:
     - eln
     - c10s


### PR DESCRIPTION
- insights-core-selinux is a new package that will be added to RHEL 9.7/10.1. It's required when installing the insights-client.
- Jira: RHELPLAN-172287