### PR TITLE
kde: update for Plasma 6.4

### DIFF
--- a/configs/eln_extras_kde.yaml
+++ b/configs/eln_extras_kde.yaml
@@ -13,6 +13,7 @@ data:
     - atlantik
     - audex
     - audiotube
+    - aurorae
     - baloo-widgets
     - blinken
     - bomber
@@ -257,7 +258,6 @@ data:
     - kwave
     - kweather
     - kwin
-    - kwin-wayland
     - kwordquiz
     - kwrite
     - kwrited
@@ -326,7 +326,6 @@ data:
     - plasma-workspace
     - plasma-workspace-geolocation
     - plasma-workspace-wallpapers
-    - plasma-workspace-wayland
     - polkit-kde
     - polkit-qt6-1
     - powerdevil


### PR DESCRIPTION
aurorae was split out of kwin, and the -wayland subpackages of kwin and plasma-workspace were merged into their respective main packages.

https://src.fedoraproject.org/rpms/aurorae/c/ff4c7a3097a85a0daa15cad61bedb7606d20437a
https://src.fedoraproject.org/rpms/kwin/c/42743fd578831cec12a7fe935097919d4aec03d9
https://src.fedoraproject.org/rpms/plasma-workspace/c/36c500230d304de5576ce6a14f036ae16b7bbbff

/cc @tdawson 