### PR TITLE
Add bindgen-cli and cbindgen to rust-toolset

### DIFF
--- a/configs/rhel-sst-pt-llvm-rust-go--rust-toolset.yaml
+++ b/configs/rhel-sst-pt-llvm-rust-go--rust-toolset.yaml
@@ -18,6 +18,8 @@ data:
     - rustfmt
     - rust-toolset-srpm-macros
     - rust-toolset
+    - bindgen-cli
+    - cbindgen
   arch_packages:
     aarch64:
       - rust-std-static-aarch64-unknown-none-softfloat


### PR DESCRIPTION
We are adding these command-line tools, but notably **not** any of Fedora's `*-devel` subpackages.