### PR TITLE
Drop python-urwid

### DIFF
--- a/configs/rhel-sst-storage-io--packages.yaml
+++ b/configs/rhel-sst-storage-io--packages.yaml
@@ -24,7 +24,6 @@ data:
     - python3-kmod
     - python3-pyparsing
     - python3-rtslib
-    - python3-urwid
     - targetcli
     # iscsi
     - iscsi-initiator-utils


### PR DESCRIPTION
This was previously a requirement of python-configshell, but no longer:

https://github.com/open-iscsi/configshell-fb/commit/7513c74d92f755c0debb10b95ffec1c3815647ee

/cc @maurizio-lombardi 