### PR TITLE
[meta] Re-enable python-testslide

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -54,7 +54,7 @@ data:
     - pore
     - pv
     - python3-pystemd
-#    - python3-testslide
+    - python3-testslide
     - python3-zstd
     - qrencode-devel
     - ragel


### PR DESCRIPTION
This is now built for Python 3.14:
https://koji.fedoraproject.org/koji/taskinfo?taskID=134758562