### PR TITLE
Add secvarctl to el9 and el10

### DIFF
--- a/configs/rhel-sst-cs-bootloaders--secvarctl.yaml
+++ b/configs/rhel-sst-cs-bootloaders--secvarctl.yaml
@@ -1,0 +1,13 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: secvarctl
+  description: Tool to manage Secure Boot variables on POWER
+  maintainer: rhel-sst-cs-bootloaders
+  packages: []
+  labels:
+    - eln
+    - c10s
+  arch_packages:
+    ppc64le:
+      - secvarctl


### PR DESCRIPTION
secvarctl is a suite of tools to manage Secure Boot variables on POWER, and is needed for dynamic key management, which is finally being added to RHEL.