### PR TITLE
Update kernel-rt configs

### DIFF
--- a/configs/rhel-sst-kernel-rts--kernel-rt-base.yaml
+++ b/configs/rhel-sst-kernel-rts--kernel-rt-base.yaml
@@ -10,43 +10,27 @@ data:
     - c10s
   arch_packages:
     x86_64:
+      - kernel-rt
+      - kernel-rt-core
+      - kernel-rt-modules
+      - kernel-rt-modules-core
+      - kernel-rt-modules-extra
       - tuned-profiles-realtime
       - tuned-profiles-nfv
       - tuned-profiles-nfv-guest
       - tuned-profiles-nfv-host
-  # RHEL-specific subpackages, not available in Fedora
-  package_placeholders:
-    - srpm_name: kernel
-      build_dependencies: []
-      rpms:
-        - rpm_name: kernel-rt
-          dependencies:
-            - realtime-setup
-          limit_arches:
-            - x86_64
-        - rpm_name: kernel-rt-core
-          dependencies:
-            - bash
-            - systemd-udev
-            - coreutils
-            - dracut
-            - linux-firmware
-            - systemd
-          limit_arches:
-            - x86_64
-        - rpm_name: kernel-rt-modules
-          dependencies: []
-          limit_arches:
-            - x86_64
-        - rpm_name: kernel-rt-modules-core
-          dependencies: []
-          limit_arches:
-            - x86_64
-        - rpm_name: kernel-rt-modules-extra
-          dependencies: []
-          limit_arches:
-            - x86_64
-        - rpm_name: kernel-rt-kvm
-          dependencies: []
-          limit_arches:
-            - x86_64
+    aarch64:
+      - kernel-rt-64k
+      - kernel-rt-64k-core
+      - kernel-rt-64k-modules
+      - kernel-rt-64k-modules-core
+      - kernel-rt-64k-modules-extra
+      - kernel-rt
+      - kernel-rt-core
+      - kernel-rt-modules
+      - kernel-rt-modules-core
+      - kernel-rt-modules-extra
+      - tuned-profiles-realtime
+      - tuned-profiles-nfv
+      - tuned-profiles-nfv-guest
+      - tuned-profiles-nfv-host

--- a/configs/rhel-sst-kernel-rts--kernel-rt-develdebug.yaml
+++ b/configs/rhel-sst-kernel-rts--kernel-rt-develdebug.yaml
@@ -8,63 +8,33 @@ data:
   labels:
     - eln
     - c10s
-  # RHEL-specific subpackages, not available in Fedora
-  package_placeholders:
-    - srpm_name: kernel
-      build_dependencies: []
-      rpms:
-        - rpm_name: kernel-rt-debug
-          dependencies:
-            - realtime-setup
-          limit_arches:
-            - x86_64
-        - rpm_name: kernel-rt-debug-core
-          dependencies:
-            - bash
-            - systemd-udev
-            - coreutils
-            - dracut
-            - linux-firmware
-            - systemd
-          limit_arches:
-            - x86_64
-        - rpm_name: kernel-rt-debug-modules
-          dependencies: []
-          limit_arches:
-            - x86_64
-        - rpm_name: kernel-rt-debug-modules-core
-          dependencies: []
-          limit_arches:
-            - x86_64
-        - rpm_name: kernel-rt-debug-modules-extra
-          dependencies: []
-          limit_arches:
-            - x86_64
-        - rpm_name: kernel-rt-debug-kvm
-          dependencies: []
-          limit_arches:
-            - x86_64
-        - rpm_name: kernel-rt-debug-devel
-          dependencies:
-            - bison
-            - elfutils-libelf-devel
-            - findutils
-            - flex
-            - gcc
-            - make
-            - openssl-devel
-            - perl-interpreter
-          limit_arches:
-            - x86_64
-        - rpm_name: kernel-rt-devel
-          dependencies:
-            - bison
-            - elfutils-libelf-devel
-            - findutils
-            - flex
-            - gcc
-            - make
-            - openssl-devel
-            - perl-interpreter
-          limit_arches:
-            - x86_64
+  arch_packages:
+    x86_64:
+      - kernel-rt-debug
+      - kernel-rt-debug-core
+      - kernel-rt-debug-devel
+      - kernel-rt-debug-devel-matched
+      - kernel-rt-debug-modules
+      - kernel-rt-debug-modules-core
+      - kernel-rt-debug-modules-extra
+      - kernel-rt-devel
+      - kernel-rt-devel-matched
+    aarch64:
+      - kernel-rt-64k-debug
+      - kernel-rt-64k-debug-core
+      - kernel-rt-64k-debug-devel
+      - kernel-rt-64k-debug-devel-matched
+      - kernel-rt-64k-debug-modules
+      - kernel-rt-64k-debug-modules-core
+      - kernel-rt-64k-debug-modules-extra
+      - kernel-rt-64k-devel
+      - kernel-rt-64k-devel-matched
+      - kernel-rt-debug
+      - kernel-rt-debug-core
+      - kernel-rt-debug-devel
+      - kernel-rt-debug-devel-matched
+      - kernel-rt-debug-modules
+      - kernel-rt-debug-modules-core
+      - kernel-rt-debug-modules-extra
+      - kernel-rt-devel
+      - kernel-rt-devel-matched


### PR DESCRIPTION
kernel-rt is now built in the ARK (ELN) kernel and is enabled for aarch64 with a 64k variant.  The -kvm subpackages have been merged into -modules-core. Also, add -devel-matched subpackages.