### PR TITLE
mailman3: disable mailman-web

### DIFF
--- a/configs/eln_extras_mailman3.yaml
+++ b/configs/eln_extras_mailman3.yaml
@@ -7,6 +7,6 @@ data:
   packages:
     - mailman3
     - python3-mailman-hyperkitty
-    - python3-mailman-web
+    #- python3-mailman-web
   labels:
     - eln-extras


### PR DESCRIPTION
python-django42 was retired from Fedora, but this has yet to be ported to newer versions of Django.

/cc @michel-slm 