### PR TITLE
Unwanted list cleanup, part 1

### DIFF
--- a/configs/rhel-sst-cs-base-utils--unwanted-java.yaml
+++ b/configs/rhel-sst-cs-base-utils--unwanted-java.yaml
@@ -50,7 +50,6 @@ data:
     - plexus-build-api
     - plexus-component-api
     - plexus-i18n
-    - plexus-interactivity
     - plexus-velocity
     - sonatype-oss-parent
     - spec-version-maven-plugin

--- a/configs/rhel-sst-cs-base-utils--unwanted.yaml
+++ b/configs/rhel-sst-cs-base-utils--unwanted.yaml
@@ -6,13 +6,10 @@ data:
   maintainer: rhel-sst-cs-base-utils
   unwanted_packages:
     - linuxconsoletools
-    - mtools
     - expectk
-    - openwsman-python3
     - openwsman-perl
     - rubygem-openwsman
     - openwsman-winrs
-    - openwsman-client
     - rubygem-openwsman-doc
     - sblim-cmpi-base-test
     - tix-doc

--- a/configs/rhel-sst-cs-databases--unwanted.yaml
+++ b/configs/rhel-sst-cs-databases--unwanted.yaml
@@ -15,8 +15,6 @@ data:
     # https://fedoraproject.org/wiki/Changes/AspellDeprecation
     - aspell
     - aspell-devel
-    # Seems like not much wanted
-    - python3-pyodbc
   labels:
     - eln
     - c10s

--- a/configs/rhel-sst-cs-plumbers--unwanted.yaml
+++ b/configs/rhel-sst-cs-plumbers--unwanted.yaml
@@ -20,7 +20,6 @@ data:
     - atlas-z196
     - atlas-z196-devel
     - atlas-z196-static
-    - ed
     - emacs-terminal
     - libnice
     - libnice-devel

--- a/configs/rhel-sst-display-hardware-multimedia--unwanted.yaml
+++ b/configs/rhel-sst-display-hardware-multimedia--unwanted.yaml
@@ -21,8 +21,6 @@ data:
     - SFML
     # Only used by some multimedia apps we don't ship
     - libmpcdec
-    # Seems unused
-    - libsamplerate
     # Only used by openal-soft examples, brings in other unwanted deps
     - SDL_sound
   unwanted_packages:

--- a/configs/rhel-sst-filesystems--userspace-unwanted.yaml
+++ b/configs/rhel-sst-filesystems--userspace-unwanted.yaml
@@ -6,7 +6,6 @@ data:
   maintainer: rhel-sst-filesystems
   unwanted_packages:
     - system-storage-manager
-    - xmlstarlet
     - oath-toolkit
     - luarocks
     - leveldb

--- a/configs/rhel-sst-pt-gcc--unwanted.yaml
+++ b/configs/rhel-sst-pt-gcc--unwanted.yaml
@@ -22,13 +22,6 @@ data:
     - dpkg
     - dpkg-devel
     - dselect
-    # Nasm is a build requirement for: dav1d, firefox, libavif, libjpeg-turbo,
-    # mingw-libjpeg-turbo, qatlib, rust-rav1e, syslinux, thunderbird, vmaf 
-    # Ideally one of these packages will take over the maintainership.
-    # Either that or they will all switch to using the binutils assembler
-    # and drop the nasm build requirement.
-    - nasm
-    - nasm-rdoff
     # Yasm is a build requirement for: firefox, libvpx, svt-av1 and thunderbird.
     # Ideally one of these packages will take over the maintainership.
     # Either that or they will all switch to using the binutils assembler

--- a/configs/rhel-sst-rh-ceph-storage--unwanted.yaml
+++ b/configs/rhel-sst-rh-ceph-storage--unwanted.yaml
@@ -25,7 +25,6 @@ data:
     - libcephfs2
     - libcephfs_jni-devel
     - libcephfs_jni1
-    - libradospp-devel
     - libradosstriper-devel
     - libradosstriper1
     - librgw-devel

--- a/configs/rhel-sst-security-selinux--python-networkx-unwanted.yaml
+++ b/configs/rhel-sst-security-selinux--python-networkx-unwanted.yaml
@@ -52,7 +52,6 @@ data:
   #
   # (optional field)
   unwanted_source_packages:
-    - gdal
     - pydot
     - python-nb2plots
     - python-pygraphviz


### PR DESCRIPTION
There have been various uses of the "unwanted" designation in CR.  Some SSTs have used it to say that *they* don't want to maintain the package (but the package is ultimately needed), others have used it to say that a package should be buildroot only (iow it's unwanted in shipped repos, but is ultimately needed in the buildroot).  This is the first step in moving towards a single definition: the package should not be in RHEL at all.

This group of packages are shipped and are clearly not going anywhere; some of these are simply obsolete unwantedness, as new packages have begun to require them.

/cc @bstinsonmhk 