### PR TITLE
cs-databases: PostreSQL 18 update

### DIFF
--- a/configs/rhel-sst-cs-databases--db-postgresql-extensions.yaml
+++ b/configs/rhel-sst-cs-databases--db-postgresql-extensions.yaml
@@ -1,0 +1,15 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: PostgreSQL extensions
+  description: Server extensions for PostgreSQL
+  maintainer: rhel-sst-cs-databases
+  packages:
+    - pgaudit
+    - pg_repack
+    - pgvector
+    - postgres-decoderbufs
+    - postgis
+  labels:
+    - eln
+    - c10s

--- a/configs/rhel-sst-cs-databases--db-postgresql.yaml
+++ b/configs/rhel-sst-cs-databases--db-postgresql.yaml
@@ -2,25 +2,20 @@ document: feedback-pipeline-workload
 version: 1
 data:
   name: PostgreSQL client and server
-  description: Client tools and a server daemon for PostgreSQL, with some plugins
+  description: Client tools and a server daemon for PostgreSQL
   maintainer: rhel-sst-cs-databases
   packages:
     - postgresql
     - postgresql-contrib
     - postgresql-plperl
     - postgresql-plpython3
-    - postgresql-pltcl
+    #- postgresql-pltcl
     - postgresql-server
     - postgresql-server-devel
     - postgresql-static
     - postgresql-test
     - postgresql-upgrade
     - postgresql-upgrade-devel
-    - pgaudit
-    - pg_repack
-    - pgvector
-    - postgres-decoderbufs
-    - postgis
   labels:
     - eln
     - c10s


### PR DESCRIPTION
postgresql18 has been added and now provides the unversioned (default) packages, but the extensions have yet to be rebuilt and therefore still depend on 16.

https://fedoraproject.org/wiki/Changes/PostgreSQL_18