### PR TITLE
Mark python3-wheel unwanted in ELN

### DIFF
--- a/configs/rhel-sst-pt-python-ruby-nodejs--python-crb-eln.yaml
+++ b/configs/rhel-sst-pt-python-ruby-nodejs--python-crb-eln.yaml
@@ -18,7 +18,6 @@ data:
     - python3-flit-core
     - python3-cython
     - python3-sphinx
-    - python3-wheel
     - python3-pytest
     - python3-psutil-tests
     - py3c-devel

--- a/configs/rhel-sst-pt-python-ruby-nodejs--unwanted-python3-eln.yaml
+++ b/configs/rhel-sst-pt-python-ruby-nodejs--unwanted-python3-eln.yaml
@@ -11,9 +11,12 @@ data:
     - python3.12-libs
     - python3.13
     - python3.13-libs
+    # other packages
+    - python3-wheel
   # components for the above
   unwanted_source_packages:
     - python3.12
     - python3.13
+    - python-wheel
   labels:
     - eln


### PR DESCRIPTION
See https://github.com/fedora-eln/eln/issues/284

---

Note that the package is listed in configs/rhel-sst-high-availability--userspace.yaml as a build dependency of pcs. I don't know if the package can be wanted and unwanted at the same time, but we don't want it.