### PR TITLE
Block python-black from ELN

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -96,6 +96,7 @@ data:
         # unwanted ocaml deps
         - ocaml-ounit*
         # unwanted python deps
+        - black
         - python3-anyio
         - python3-coverage
         - python3-docs


### PR DESCRIPTION
(python-)black is a Python code linter and has many unwanted dependencies:

https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_linters