### PR TITLE
chore: add insights-core-selinux to insights-core dependencies

### DIFF
--- a/configs/rhel-sst-csi-client-tools--all.yaml
+++ b/configs/rhel-sst-csi-client-tools--all.yaml
@@ -62,6 +62,7 @@ data:
             - python3-pyyaml
             - python3-requests
             - python3-six
+            - insights-core-selinux
     - srpm_name: insights-core-selinux
       rpms:
         - rpm_name: insights-core-selinux


### PR DESCRIPTION
- the insights-core-selinux should be installed as well
  when installing the insights-core RPM package