### PR TITLE
Mark netcat, libretls unwanted

### DIFF
--- a/configs/rhel-sst-networking-core--unwanted.yaml
+++ b/configs/rhel-sst-networking-core--unwanted.yaml
@@ -8,6 +8,7 @@ data:
   maintainer: rhel-sst-networking-core
   unwanted_packages:
     - dropwatch
+    - netcat
     - plotnetcfg
   labels:
     - eln

--- a/configs/rhel-sst-security-crypto--unwanted.yaml
+++ b/configs/rhel-sst-security-crypto--unwanted.yaml
@@ -11,6 +11,7 @@ data:
   # more).
   # More info in the original PR 15
   unwanted_packages:
+    - libretls
     - libsodium
     - libssh2
     - libtomcrypt


### PR DESCRIPTION
cloud-init started pulling in BSD netcat, but that is unwanted and should be temporary.

https://github.com/fedora-eln/eln/issues/239