### PR TITLE
Block golang-*-devel, and temporarily go-vendor-tools

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -170,6 +170,10 @@ data:
         - python3-simpleaudio
         # unwanted (and rarely used) build dep, pulls in hundreds of Perl deps
         - licensecheck
+        # golang module packages are obsolete and unwanted
+        - golang-*-devel
+        # needs further pruning before inclusion in RHEL
+        - go-vendor-tools*
         priority: 4
       Rawhide:
         baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/$basearch/os/


### PR DESCRIPTION
Golang packages are in the process of migrating to vendoring by default in Fedora, which will eventually mean no more golang-*-devel packages, which we didn't want in RHEL anyway.  However, go-vendor-tools needs further stripping of dependencies before it is ready for inclusion itself.

https://fedoraproject.org/wiki/Changes/GolangPackagesVendoredByDefault https://gitlab.com/fedora/sigs/go/go-vendor-tools/-/issues/3 https://github.com/fedora-eln/eln/issues/240