### PR TITLE
Drop tbb-doc

### DIFF
--- a/configs/rhel-sst-pt-libraries--tbb.yaml
+++ b/configs/rhel-sst-pt-libraries--tbb.yaml
@@ -8,7 +8,6 @@ data:
     - python3-tbb
     - tbb
     - tbb-devel
-    - tbb-doc
   labels:
     - eln
     - c10s


### PR DESCRIPTION
The doc subpackage was removed in 2022.2.0:

https://src.fedoraproject.org/rpms/tbb/c/1f933b6e919ab88d5addabed3db218954f56f597

/cc @codonell 