### PR TITLE
List git-lfs as a real package

### DIFF
--- a/configs/rhel-sst-cs-base-utils--scm.yaml
+++ b/configs/rhel-sst-cs-base-utils--scm.yaml
@@ -8,21 +8,8 @@ data:
     - git
     - git-daemon
     - git-gui
+    - git-lfs
     - gitk
   labels:
     - eln
     - c10s
-  package_placeholders:
-    # Uses vendored dependencies in RHEL
-    - srpm_name: git-lfs
-      build_dependencies:
-        - git
-        - go-rpm-macros
-        - perl-Digest-SHA
-        - perl-Test-Harness
-        - rubygem-asciidoctor
-      rpms:
-        - rpm_name: git-lfs
-          description: Git extension for versioning large files
-          dependencies:
-            - git-core


### PR DESCRIPTION
golang-*-devel build dependencies are now being filtered, and git-lfs should move soon to vendored dependencies:

https://src.fedoraproject.org/rpms/git-lfs/pull-request/6