### PR TITLE
Add fedora-ci config to Extras

### DIFF
--- a/configs/eln_extras_ci.yaml
+++ b/configs/eln_extras_ci.yaml
@@ -1,0 +1,10 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: RHEL packager
+  description: ELN Extras packages for Fedora CI
+  maintainer: fedora-ci
+  packages:
+    - beakerlib
+  labels:
+    - eln-extras


### PR DESCRIPTION
beakerlib is necessary for TMT tests, and is present in EPEL.

/cc @thrix