### PR TITLE
kde: switch to plasma-keyboard

### DIFF
--- a/configs/eln_extras_kde.yaml
+++ b/configs/eln_extras_kde.yaml
@@ -275,7 +275,6 @@ data:
     - libkworkspace6
     - lokalize
     - lskat
-    - maliit-keyboard
     - marble
     - marble-astro
     - marble-plasma
@@ -312,6 +311,7 @@ data:
     - plasma-firewall
     - plasma-firewall-firewalld
     - plasma-integration
+    - plasma-keyboard
     - plasma-milou
     - plasma-mobile
     - plasma-mobile-sounds


### PR DESCRIPTION
This replaces maliit-keyboard, which is still Qt5 based.

https://src.fedoraproject.org/rpms/plasma-workspace/c/ce6fb7a650dd33a4b0b6527997548fc2600bb1f7

/cc @tdawson 