### PR TITLE
Remove gobject-introspection from WSL lists

### DIFF
--- a/configs/rhel-program--image-wsl-c10s.yaml
+++ b/configs/rhel-program--image-wsl-c10s.yaml
@@ -25,7 +25,6 @@ data:
         - glibc-minimal-langpack
         - gmp
         - gnupg2
-        - gobject-introspection
         - hostname
         - langpacks-en
         - libcurl-minimal
@@ -70,7 +69,6 @@ data:
         - glibc-minimal-langpack
         - gmp
         - gnupg2
-        - gobject-introspection
         - hostname
         - langpacks-en
         - libcurl-minimal

--- a/configs/rhel-program--image-wsl.yaml
+++ b/configs/rhel-program--image-wsl.yaml
@@ -25,7 +25,6 @@ data:
         - glibc-minimal-langpack
         - gmp
         - gnupg2
-        - gobject-introspection
         - hostname
         - langpacks-en
         - libcurl-minimal
@@ -69,7 +68,6 @@ data:
         - glibc-minimal-langpack
         - gmp
         - gnupg2
-        - gobject-introspection
         - hostname
         - langpacks-en
         - libcurl-minimal


### PR DESCRIPTION
GObject Introspection has been merged (with a new library version and renamed tools) into the glib sources.  While the original standalone version is still a dependency of some components and will continue to be pulled in as a result, it will eventually go away.

https://docs.gtk.org/girepository/migrating-gi.html