### PR TITLE
Limit liveinstall arches

### DIFF
--- a/configs/eln_extras_liveinstall.yaml
+++ b/configs/eln_extras_liveinstall.yaml
@@ -4,9 +4,15 @@ data:
   name: liveinstall packages
   description: LiveInstall packages not in RHEL
   maintainer: tdawson
-  packages:
-    - anaconda-live
-    - livesys-scripts
-    - slitherer
+  packages: []
+  arch_packages:
+    aarch64:
+      - anaconda-live
+      - livesys-scripts
+      - slitherer
+    x86_64:
+      - anaconda-live
+      - livesys-scripts
+      - slitherer
   labels:
     - eln-extras


### PR DESCRIPTION
CentOS Alt Images are built for only x86_64 and aarch64.  ppc64le would be
possible, and Fedora does make some, but there may not be demand.
slitherer (being based on QtWebEngine) is not available for s390x though.

/cc @tdawson
