### PR TITLE
Add rhc-playbook-verifier as a dependency for rhc-worker-playbook

### DIFF
--- a/configs/rhel-sst-csi-client-tools--all.yaml
+++ b/configs/rhel-sst-csi-client-tools--all.yaml
@@ -45,6 +45,12 @@ data:
             - ansible-core
             - python3-pyyaml
             - python3-requests
+    - srpm_name: rhc-playbook-verifier
+      rpms:
+        - rpm_name: rhc-playbook-verifier
+          description: rhc-playbook-verifier
+          dependencies:
+            - python3-pyyaml
     - srpm_name: redhat-cloud-client-configuration
       rpms:
         - rpm_name: redhat-cloud-client-configuration


### PR DESCRIPTION
* Resolves: RHELMISC-18048

Since rhc-playbook-verifier will be a new RPM for RHEL 10.2, this package should be a dependency of rhc-worker-playbook.