### PR TITLE
Add python3-pyside6 to Extras

### DIFF
--- a/configs/eln_extras_qt6.yaml
+++ b/configs/eln_extras_qt6.yaml
@@ -6,6 +6,7 @@ data:
   maintainer: tdawson
   packages:
     - python3-pyqt6-charts
+    - python3-pyside6
     - qt6-doc
     - qt6-qtcoap
     - qt6-qtgraphs


### PR DESCRIPTION
This is now a build dependency of several KDE Frameworks, and needs to be updated in lockstep with Qt6.