### PR TITLE
Block ECM and KDE packages from ELN (not Extras)

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -165,7 +165,11 @@ data:
         - libswresample-free*
         - libswscale-free*
         # only qt6 in ELN
+        - kf5-*
         - qt5-*
+        # KDE is unwanted
+        - extra-cmake-modules
+        - kf6-*
         # qtwebengine is unwanted
         - qt6-qtpdf
         - qt6-qtpdf-devel


### PR DESCRIPTION
These are wanted in Extras, but not in ELN itself:

https://github.com/fedora-eln/eln/issues/478
