### PR TITLE
Drop unversioned nodejs packages from ELN

### DIFF
--- a/configs/rhel-pt-ruby-nodejs--nodejs.yaml
+++ b/configs/rhel-pt-ruby-nodejs--nodejs.yaml
@@ -9,5 +9,4 @@ data:
     - nodejs-devel
     - nodejs-npm
   labels:
-    - eln
     - c10s


### PR DESCRIPTION
The new Node.js packaging scheme no longer has default streams:

https://fedoraproject.org/wiki/Changes/NodejsAlternativesSystem
