### PR TITLE
Drop unused libkolabxml

### DIFF
--- a/configs/eln_extras_kde_misc.yaml
+++ b/configs/eln_extras_kde_misc.yaml
@@ -8,7 +8,6 @@ data:
     - atlantik
     - gcompris-qt
     - haruna
-    - java-kolabformat
     - kcolorpicker-qt6
     - kde-settings
     - kde-settings-pulseaudio
@@ -20,15 +19,12 @@ data:
     - kommit
     - krita
     - libkgapi
-    - libkolabxml
     - marknote
     - nheko
     #- okteta
     - phonon-qt6
     - phonon-qt6-backend-vlc
-    - php-kolabformat
     - polkit-qt6-1
-    - python3-kolabformat
     - qt-creator
     - qt-creator-data
     - qt-creator-doc

--- a/configs/rhel-sst-cs-software-management--unwanted-dnf.yaml
+++ b/configs/rhel-sst-cs-software-management--unwanted-dnf.yaml
@@ -1,0 +1,14 @@
+document: feedback-pipeline-unwanted
+version: 1
+data:
+  name: Unwanted DNF4 packages
+  description: DNF4 packages unwanted in RHEL 11
+  maintainer: rhel-sst-cs-software-management
+  unwanted_source_packages:
+    - dnf
+    - dnf-plugins-core
+    - libcomps
+    - libdnf
+    - libmodulemd
+  labels:
+    - eln


### PR DESCRIPTION
The Kolab resource in kdepim-runtime was removed in 26.04.0.

https://invent.kde.org/pim/kdepim-runtime/-/merge_requests/154

/cc @tdawson
