### PR TITLE
Remove fdo-rs packages from edge workload

### DIFF
--- a/configs/rhel-sst-edge--all.yaml
+++ b/configs/rhel-sst-edge--all.yaml
@@ -24,12 +24,6 @@ data:
   arch_packages:
     aarch64:
       - clevis-pin-tpm2
-      - fdo-client
-      - fdo-init
-      - fdo-manufacturing-server
-      - fdo-owner-cli
-      - fdo-owner-onboarding-server
-      - fdo-rendezvous-server
       - go-fdo-client
       - go-fdo-server
       - go-fdo-server-manufacturer
@@ -39,12 +33,6 @@ data:
       - greenboot-default-health-checks
     x86_64:
       - clevis-pin-tpm2
-      - fdo-client
-      - fdo-init
-      - fdo-manufacturing-server
-      - fdo-owner-cli
-      - fdo-owner-onboarding-server
-      - fdo-rendezvous-server
       - go-fdo-client
       - go-fdo-server
       - go-fdo-server-manufacturer

--- a/configs/rhel-sst-edge--deprecated-c10s.yaml
+++ b/configs/rhel-sst-edge--deprecated-c10s.yaml
@@ -1,0 +1,23 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Edge Deprecated
+  description: Deprecated fdo-rs (FIDO Device Onboard, Rust implementation) packages. Replaced by go-fdo. To be removed in RHEL 11.
+  maintainer: rhel-sst-edge
+  arch_packages:
+    aarch64:
+      - fdo-client
+      - fdo-init
+      - fdo-manufacturing-server
+      - fdo-owner-cli
+      - fdo-owner-onboarding-server
+      - fdo-rendezvous-server
+    x86_64:
+      - fdo-client
+      - fdo-init
+      - fdo-manufacturing-server
+      - fdo-owner-cli
+      - fdo-owner-onboarding-server
+      - fdo-rendezvous-server
+  labels:
+    - c10s


### PR DESCRIPTION
The Rust-based FIDO Device Onboard (fdo-rs) implementation is being removed in RHEL 11. The Go-based implementation (go-fdo-*) is the supported alternative.

https://redhat.atlassian.net/browse/THEEDGE-4607