### PR TITLE
Migrate to ICU 78

### DIFF
--- a/configs/rhel-sst-display-i18n--icu-compat.yaml
+++ b/configs/rhel-sst-display-i18n--icu-compat.yaml
@@ -18,7 +18,7 @@ data:
     # libicu.  At that point, CR will continue to handle the compat package 
     # normally until all dependents have been updated for the new libicu 
     # version, at which point the compat package will drop out of ELN.
-    - 'libicudata.so.77()(64bit)'
+    - 'libicudata.so.78()(64bit)'
   labels:
     - eln
     # cNs stays on a single ICU version once branched


### PR DESCRIPTION
libicu77 is now accounted for as a dependency, but shouldn't be needed for
long, as dependents were rebuilt in tandem this time.

Closes: https://github.com/fedora-eln/eln/issues/542
