### PR TITLE
Remove weldr-client from eln

### DIFF
--- a/configs/rhel-sst-image-builder--weldr-client.yaml
+++ b/configs/rhel-sst-image-builder--weldr-client.yaml
@@ -5,7 +5,6 @@ data:
   description: composer-cli command line utility to control osbuild-composer
   maintainer: rhel-sst-image-builder
   labels:
-    - eln
     - c10s
   packages:
     - weldr-client


### PR DESCRIPTION
weldr-client is deprecated in RHEL 10 and scheduled for removal in RHEL 11, so let's remove it from eln.