### PR TITLE
Update libzpc packages for ELN

### DIFF
--- a/configs/rhel-sst-arch-hw--c10s.yaml
+++ b/configs/rhel-sst-arch-hw--c10s.yaml
@@ -24,7 +24,6 @@ data:
     - alsa-utils
     - speexdsp
     - hwloc
-    - libzpc-tools
     - pigz
     - s390utils
     - s390utils-se-data
@@ -49,7 +48,8 @@ data:
       - libzfcphbaapi
       - libzfcphbaapi-devel
       - libzfcphbaapi-docs
-      - libzpc-provider
+      - libzpc
+      - libzpc-devel
       - openssl-ibmca
       - qclib
       - qclib-devel
@@ -75,4 +75,4 @@ data:
       - pcm
       - tboot
   labels:
-    - eln
+    - c10s


### PR DESCRIPTION
As of libzpc 2.0.0, the shared library has been dropped, an OpenSSL provider added for s390x, and a multi-arch tool added:

https://src.fedoraproject.org/rpms/libzpc/c/8e47575a8a96dd97949e66a048a9246e464064b5

@sharkcz can you please confirm the following:

* That the standalone library is no longer wanted for RHEL 11?
* If the tool should be shipped on all arches?
* The manpages require `pandoc` which is not included in RHEL, so the RHEL package will manage without them?
* Will this change be coming back to RHEL 10?