### PR TITLE
Temporarily disable python3-testslide

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -51,7 +51,7 @@ data:
     - pngquant
     - pv
     - python3-pystemd
-    - python3-testslide
+#    - python3-testslide
     - python3-zstd
     - qrencode-devel
     - ragel


### PR DESCRIPTION
This has yet to be rebuilt for Python 3.15, and is breaking the rest of the payload as a result.
