### PR TITLE
Re-enable testslide as a separate workload

### DIFF
--- a/configs/eln_extras_meta.yaml
+++ b/configs/eln_extras_meta.yaml
@@ -51,7 +51,6 @@ data:
     - pngquant
     - pv
     - python3-pystemd
-#    - python3-testslide
     - python3-zstd
     - qrencode-devel
     - ragel

--- a/configs/eln_extras_meta_testslide.yaml
+++ b/configs/eln_extras_meta_testslide.yaml
@@ -1,0 +1,10 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: meta-sig testslide packages
+  description: ELN Extras packages for Python testing
+  maintainer: meta-sig
+  packages:
+    - python3-testslide
+  labels:
+    - eln-extras


### PR DESCRIPTION
TestSlide has several dependencies and is often delayed during Python rebuilds as a result.  A separate workload prevents this from breaking other workloads in the meantime.
